### PR TITLE
Added changelog and changed the version of the program

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+### 2017-10-31 v0.8.0-beta
++ Automatical database saving while new finish or readout
++ Automatical SPORTident station connection
++ Remember the last used directory
++ Opening of recent file
++ Submenu "Recent files"
++ Templates (start list, results) were updated
++ Automatical split printing while readout
+- "Open with" option for *.sportorg extention
+- Mixing several groups while tossing
+- Winorient import - splits import was fixed
+
+
 ### 2017-10-17 v0.7.2-beta
 
 * Init

--- a/sportorg/config.py
+++ b/sportorg/config.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 NAME = 'SportOrg'
-VERSION = '0.7.2-beta'
+VERSION = '0.8.0-beta'
 DEBUG = True
 
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,15 +3,15 @@
 	{
 		"FileVersion": {
 			"Major": 0,
-			"Minor": 7,
-			"Patch": 2,
-			"Build": 2
+			"Minor": 8,
+			"Patch": 0,
+			"Build": 0
 		},
 		"ProductVersion": {
 			"Major": 0,
-			"Minor": 7,
-			"Patch": 2,
-			"Build": 2
+			"Minor": 8,
+			"Patch": 0,
+			"Build": 0
 		},
 		"FileFlagsMask": "3f",
 		"FileFlags ": "00",
@@ -24,14 +24,14 @@
 		"Comments": "SportOrg program",
 		"CompanyName": "SportOrg",
 		"FileDescription": "SportOrg",
-		"FileVersion": "0.7.2.2",
+		"FileVersion": "0.8.0.0",
 		"InternalName": "SportOrg",
 		"LegalCopyright": "MIT Licence SportOrg",
 		"LegalTrademarks": "",
 		"OriginalFilename": "SportOrg",
 		"PrivateBuild": "",
 		"ProductName": "SportOrg",
-		"ProductVersion": "v0.7.2-beta",
+		"ProductVersion": "v0.8.0-beta",
 		"SpecialBuild": ""
 	},
 	"VarFileInfo":


### PR DESCRIPTION
### 2017-10-31 v0.8.0-beta
+ Automatical database saving while new finish or readout
+ Automatical SPORTident station connection
+ Remember the last used directory
+ Opening of recent file
+ Submenu "Recent files"
+ Templates (start list, results) were updated
+ Automatical split printing while readout
- "Open with" option for *.sportorg extention
- Mixing several groups while tossing
- Winorient import - splits import was fixed