### PR TITLE
Templates bib: remove body margin

### DIFF
--- a/templates/start/4_bib.html
+++ b/templates/start/4_bib.html
@@ -141,6 +141,7 @@
                 margin: 0.5cm;
             }
             body {
+                margin: 0;
                 zoom: 50%;
             }
             table {


### PR DESCRIPTION
Комит решает проблему на половину пустой первой страницы при печати номеров.
![image](https://user-images.githubusercontent.com/37730459/52915285-cb413200-32f3-11e9-9129-ec403cba2b88.png)
