### PR TITLE
Fix QThread crash, CP range, card number as bib

### DIFF
--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -829,6 +829,9 @@ msgstr "Файл IOF xml (*.xml)"
 msgid "Use bib as card number"
 msgstr "Заменить номера чипов нагрудными номерами"
 
+msgid "Use card number as bib"
+msgstr "Заменить нагрудные номера номерами чипов"
+
 msgid "No results to change status"
 msgstr "Нет результата для изменения статуса"
 

--- a/sportorg/gui/main_window.py
+++ b/sportorg/gui/main_window.py
@@ -2,10 +2,8 @@ import ast
 import logging
 import time
 from queue import Queue
-from threading import main_thread
-
 from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtCore import QModelIndex, QItemSelectionModel, QThread, Signal
+from PySide2.QtCore import QModelIndex, QItemSelectionModel, QTimer, Signal
 from PySide2.QtWidgets import QMainWindow, QTableView, QMessageBox
 
 from sportorg import config
@@ -38,18 +36,6 @@ from sportorg.modules.sportident.sireader import SIReaderClient
 from sportorg.modules.sportiduino.sportiduino import SportiduinoClient
 from sportorg.modules.teamwork import Teamwork
 from sportorg.modules.telegram.telegram import TelegramClient
-
-
-@singleton
-class ServiceListenerThread(QThread):
-    interval = Signal()
-
-    def run(self):
-        while True:
-            time.sleep(1)
-            if not main_thread().is_alive():
-                break
-            self.interval.emit()
 
 
 class ConsolePanelHandler(logging.Handler):
@@ -156,8 +142,9 @@ class MainWindow(QMainWindow):
         SportiduinoClient().set_call(self.add_sportiduino_result_from_reader)
         SFRReaderClient().set_call(self.add_sfr_result_from_reader)
 
-        ServiceListenerThread().interval.connect(self.interval)
-        ServiceListenerThread().start()
+        self.service_timer = QTimer(self)
+        self.service_timer.timeout.connect(self.interval)
+        self.service_timer.start(1000) # msec
         LiveClient().init()
         self._menu_disable(self.current_tab)
 

--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -38,7 +38,7 @@ from sportorg.libs.winorient.wdb import write_wdb
 from sportorg.models.memory import race, ResultStatus, ResultManual, find
 from sportorg.models.result.result_calculation import ResultCalculation
 from sportorg.models.result.result_checker import ResultChecker
-from sportorg.models.start.start_preparation import guess_corridors_for_groups, copy_bib_to_card_number
+from sportorg.models.start.start_preparation import guess_corridors_for_groups, copy_bib_to_card_number, copy_card_number_to_bib
 from sportorg.modules import testing
 from sportorg.modules.backup.json import get_races_from_file
 from sportorg.modules.iof import iof_xml
@@ -327,6 +327,15 @@ class CopyBibToCardNumber(Action):
         reply = messageBoxQuestion(self.app, _('Question'), msg, QMessageBox.Yes | QMessageBox.No)
         if reply == QMessageBox.Yes:
             copy_bib_to_card_number()
+            self.app.refresh()
+
+
+class CopyCardNumberToBib(Action):
+    def execute(self):
+        msg = _('Use card number as bib') + '?'
+        reply = messageBoxQuestion(self.app, _('Question'), msg, QMessageBox.Yes | QMessageBox.No)
+        if reply == QMessageBox.Yes:
+            copy_card_number_to_bib()
             self.app.refresh()
 
 
@@ -646,6 +655,7 @@ __all__ = [
     'StartHandicapAction',
     'RelayCloneAction',
     'CopyBibToCardNumber',
+    'CopyCardNumberToBib',
     'ManualFinishAction',
     'SPORTidentReadoutAction',
     'SportiduinoReadoutAction',

--- a/sportorg/gui/menu/factory.py
+++ b/sportorg/gui/menu/factory.py
@@ -39,6 +39,7 @@ class Factory(object):
             StartHandicapAction(),
             RelayCloneAction(),
             CopyBibToCardNumber(),
+            CopyCardNumberToBib(),
             ManualFinishAction(),
             SPORTidentReadoutAction(),
             SportiduinoReadoutAction(),

--- a/sportorg/gui/menu/menu.py
+++ b/sportorg/gui/menu/menu.py
@@ -223,6 +223,10 @@ def menu_list():
                     'title': _('Use bib as card number'),
                     'action': 'CopyBibToCardNumber'
                 },
+                {
+                    'title': _('Use card number as bib'),
+                    'action': 'CopyCardNumberToBib'
+                },
             ]
         },
         {

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -1,3 +1,4 @@
+import re
 import datetime
 import time
 import uuid
@@ -881,16 +882,15 @@ class ResultSportident(Result):
                 ind_end = template.find(')')
                 if ind_begin > 0 and ind_end > 0:
                     list_exists = True
-                    if template.find('-'):
-                        # any control from the range e.g. '%(31-36)'
-                        begin_cp, end_cp = template[ind_begin + 1:ind_end].split('-')
-                        if int(cur_code) >= int(begin_cp) and int(cur_code) <= int(end_cp):
+                    # any control from the list e.g. '%(31,32,35-45)'
+                    arr = re.split(r'\s*,\s*', template[ind_begin + 1:ind_end])
+                    for cp in arr:
+                        cp_range = re.split(r'\s*-\s*', cp)
+                        if int(cur_code) == int(cp_range[0]):
                             list_contains = True
-                    else:
-                        # any control from the list e.g. '%(31,32,33)'
-                        arr = template[ind_begin + 1:ind_end].split(',')
-                        if str(cur_code) in arr:
-                            list_contains = True
+                        elif len(cp_range) > 1:
+                            if int(cur_code) > int(cp_range[0]) and int(cur_code) <= int(cp_range[len(cp_range)-1]):
+                                list_contains = True
 
                 if template.find('%') > -1:
                     # non-unique control

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -881,10 +881,16 @@ class ResultSportident(Result):
                 ind_end = template.find(')')
                 if ind_begin > 0 and ind_end > 0:
                     list_exists = True
-                    # any control from the list e.g. '%(31,32,33)'
-                    arr = template[ind_begin + 1:ind_end].split(',')
-                    if str(cur_code) in arr:
-                        list_contains = True
+                    if template.find('-'):
+                        # any control from the range e.g. '%(31-36)'
+                        begin_cp, end_cp = template[ind_begin + 1:ind_end].split('-')
+                        if int(cur_code) >= int(begin_cp) and int(cur_code) <= int(end_cp):
+                            list_contains = True
+                    else:
+                        # any control from the list e.g. '%(31,32,33)'
+                        arr = template[ind_begin + 1:ind_end].split(',')
+                        if str(cur_code) in arr:
+                            list_contains = True
 
                 if template.find('%') > -1:
                     # non-unique control

--- a/sportorg/models/start/start_preparation.py
+++ b/sportorg/models/start/start_preparation.py
@@ -490,6 +490,13 @@ def copy_bib_to_card_number():
             person.card_number = person.bib
 
 
+def copy_card_number_to_bib():
+    obj = race()
+    for person in obj.persons:
+        if person.card_number:
+            person.bib = person.card_number
+
+
 def clone_relay_legs(min_bib, max_bib, increment):
     """Clone existing relay legs to new (the same names, bib += increment"""
     if min_bib + increment < max_bib:


### PR DESCRIPTION
- Using QTimer instead QThread in main_window.py (prevent error: `QThread: Destroyed while thread is still running`).
- Added action "Use card number as bib".
- Added CP range for course settings (e. g. `*(31-35)`)