### PR TITLE
Cyrillic values in json are stored as unicode

### DIFF
--- a/sportorg/libs/template/template.py
+++ b/sportorg/libs/template/template.py
@@ -45,6 +45,7 @@ def get_text_from_template(searchpath, path, **kwargs):
     )
     env.filters['tohhmmss'] = to_hhmmss
     env.filters['date'] = date
+    env.policies['json.dumps_kwargs']['ensure_ascii'] = False
     template = env.get_template(path)
 
     return template.render(**kwargs)

--- a/sportorg/modules/backup/json.py
+++ b/sportorg/modules/backup/json.py
@@ -15,7 +15,7 @@ def dump(file):
         'current_race': get_current_race_index(),
         'races': [race_downgrade(r.to_dict()) for r in races()]
     }
-    json.dump(data, file, sort_keys=True, indent=2)
+    json.dump(data, file, sort_keys=True, indent=2, ensure_ascii=False)
 
 
 def load(file):


### PR DESCRIPTION
Кириллические значения в файле сохранения и в протоколе старта / результатов сохраняются в unicode вместо \uXXXX ескейп-последовательностей. Появляется возможность быстро найти или внести исправление в протокол или в базу в текстовом редакторе, не запуская SportOrg.

Обратная совместимость сохраняется: старые json-файлы открываются в новом SportOrg, новые json-файлы открываются в старом SportOrg.