### PR TITLE
Make results more compact in text version

### DIFF
--- a/templates/reports/1_results.html
+++ b/templates/reports/1_results.html
@@ -47,15 +47,15 @@
                     index: 0,
                     name: (result.person.surname + ' ' + result.person.name).slice(0, MAX_PERSON_NAME),
                     org: (result.person.organization && String(result.person.organization.name).slice(0, MAX_ORG_NAME)) || '',
-                    qual: Qualification[result.person.qual],
+                    qual: result.person.qual ? Qualification[result.person.qual] : '',
                     bib: result.person.bib,
                     year: result.person.birth_date ? (new Date(result.person.birth_date)).getFullYear() : '',
-                    penalty_time: toHHMMSS(result.penalty_time),
+                    penalty_time: toMMSS(result.penalty_time),
                     penalty_laps: result.penalty_laps,
                     result: result.result,
                     result_relay: result.result_relay,
                     result_msec: result.result_msec,
-                    diff: race.settings.result_processing_mode === 'scores' ? result.diff_scores : toHHMMSS(result.diff),
+                    diff: race.settings.result_processing_mode === 'scores' ? result.diff_scores : '+' + toMMSS(result.diff),
                     place: result.place,
                     status: result.status,
                     scores: result.scores,
@@ -220,14 +220,14 @@
                     index: 0,
                     name: (result.person.surname + ' ' + result.person.name).slice(0, MAX_PERSON_NAME),
                     org: (result.person.organization && String(result.person.organization.name).slice(0, MAX_ORG_NAME)) || '',
-                    qual: Qualification[result.person.qual],
+                    qual: result.person.qual ? Qualification[result.person.qual] : '',
                     bib: result.person.bib,
                     year: result.person.birth_date ? (new Date(result.person.birth_date)).getFullYear() : '',
-                    penalty_time: toHHMMSS(result.penalty_time),
+                    penalty_time: toMMSS(result.penalty_time),
                     penalty_laps: result.penalty_laps,
                     result: result.result,
                     result_msec: result.result_msec,
-                    diff: race.settings.result_processing_mode === 'scores' ? result.diff_scores : toHHMMSS(result.diff),
+                    diff: race.settings.result_processing_mode === 'scores' ? result.diff_scores : '+' + toMMSS(result.diff),
                     place: result.place,
                     status: result.status,
                     scores: result.scores,
@@ -472,21 +472,21 @@
 
     var Fields = {
         fields: [
-            {key: 'index', title: '№', size: 4},
+            {key: 'index', title: '№', size: 4, align_right: true},
             {key: 'group', title: 'Группа', size: 10, active: false},
             {key: 'name', title: 'Фамилия, имя', size: 30},
             {key: 'org', title: 'Коллектив', size: 20},
-            {key: 'year', title: 'ГР', size: 5},
-            {key: 'qual', title: 'Разряд', size: 7},
-            {key: 'bib', title: 'Номер', size: 6},
-            {key: 'penalty_time', title: 'Штраф', size: 9, active: false},
-            {key: 'penalty_laps', title: 'Штраф', size: 9, active: false},
-            {key: 'result', title: 'Результат', size: 14},
-            {key: 'result_relay', title: 'Ком. рез-т', size: 14},
-            {key: 'diff', title: 'Отставание', size: 11},
-            {key: 'speed', title: 'Темп', size: 12, active: false},
-            {key: 'place_show', title: 'Место', size: 6},
-            {key: 'scores', title: 'Очки', size: 5, active: false},
+            {key: 'qual', title: 'Разряд', size: 6},
+            {key: 'year', title: 'ГР ', size: 4, align_right: true},
+            {key: 'bib', title: 'Номер', size: 5, align_right: true},
+            {key: 'penalty_time', title: 'Штраф', size: 6, active: false},
+            {key: 'penalty_laps', title: 'Штраф', size: 6, align_right: true, active: false},
+            {key: 'result', title: 'Результат', size: 13},
+            {key: 'result_relay', title: 'Ком. рез-т', size: 13},
+            {key: 'diff', title: 'Отставан', size: 8},
+            {key: 'speed', title: 'Темп', size: 8, align_right: true, active: false},
+            {key: 'place_show', title: 'Место', size: 5, align_right: true},
+            {key: 'scores', title: 'Очки', size: 4, align_right: true, active: false},
             {key: 'all_splits', title: 'Сплиты', active: false}
         ],
         active: function (key, val) {
@@ -689,6 +689,14 @@
             value: !!store.tableView,
             change: function (checked) {
                 store.tableView = checked;
+                render()
+            }
+        },
+        {
+            title: 'Разряд',
+            value: Fields.isActive('qual'),
+            change: function (checked) {
+                Fields.active('qual', checked);
                 render()
             }
         },

--- a/templates/script.js.html
+++ b/templates/script.js.html
@@ -172,20 +172,19 @@
             return node;
         };
 
-        TableTextGenerator.prototype.getSliceText = function (text, size) {
+        TableTextGenerator.prototype.getSliceText = function (text, size, align_right=false) {
             if (text === undefined) {
                 text = '';
             }
             text = String(text);
             if (size) {
-                text = text.slice(0, size);
-                if (text.length < size + 1) {
-                    var arr = [];
-                    for (var i = 0; i < size + 1 - text.length; i++) {
-                        arr.push(' ');
-                    }
-                    text += arr.join('');
+                if (align_right) {
+                    text = text.padStart(size);
+                } else {
+                    text = text.padEnd(size);
                 }
+                text = text.slice(0, size);
+                text += ' ';
             } else {
                 text += '\t';
             }
@@ -199,8 +198,9 @@
                 var h = this.getHeaderObj(key);
                 var title = h && h.title;
                 var size = h && h.size;
+                var align_right = h && h.align_right;
                 if (size) {
-                    text += this.getSliceText(title, size);
+                    text += this.getSliceText(title, size, align_right);
                 } else {
                     text += title;
                 }
@@ -224,8 +224,9 @@
                         var key = _a[_i];
                         var h = this.getHeaderObj(key);
                         var size = h && h.size;
+                        var align_right = h && h.align_right;
                         if (size) {
-                            text += this.getSliceText(obj[key], size);
+                            text += this.getSliceText(obj[key], size, align_right);
                         } else {
                             text += obj[key];
                         }
@@ -393,24 +394,36 @@
         return SettingsGenerator;
     }());
 
+    function make_date(msec) {
+        msec /= 1000;
+        var hours = Math.floor(msec / 3600);
+        msec %= 3600;
+        var minutes = Math.floor(msec / 60);
+        var seconds = ~~(msec % 60);
+
+        return new Date(2000, 0, 1, hours, minutes, seconds);
+    }
+
+    var with0 = function (dd) {
+        return (dd < 10 ? '0' + dd : dd) + '';
+    }
+
     function toHHMMSS(value) {
         if (value === 0) {
             return '00:00:00'
         }
         if (!value) return '';
-        value /= 1000;
-        var hours = Math.floor(value / 3600);
-        value %= 3600;
-        var minutes = Math.floor(value / 60);
-        var seconds = ~~(value % 60);
-
-        var date = new Date(2000, 0, 1, hours, minutes, seconds);
-
-        var with0 = function (dd) {
-            return (dd < 10 ? '0' + dd : dd) + '';
-        };
-
+        date = make_date(value);
         return with0(date.getHours()) + ':' + with0(date.getMinutes()) + ':' + with0(date.getSeconds());
+    }
+
+    function toMMSS(value) {
+        if (value === 0) {
+            return '00:00'
+        }
+        if (!value) return '';
+        date = make_date(value);
+        return with0(date.getMinutes()) + ':' + with0(date.getSeconds());
     }
 
     function getById(list, id) {
@@ -439,16 +452,6 @@
         for (var _d = 0, _e = race.groups; _d < _e.length; _d++) {
             var obj = _e[_d];
             obj.course = getById(race.courses, obj.course_id);
-        }
-        for (var _f = 0, _g = ['groups', 'courses', 'organizations']; _f < _g.length; _f++) {
-            var itemName = _g[_f];
-            race[itemName].sort(function (a, b) {
-                if (a.name.toUpperCase() < b.name.toUpperCase())
-                    return -1;
-                if (a.name.toUpperCase() > b.name.toUpperCase())
-                    return 1;
-                return 0;
-            });
         }
         return race;
     }


### PR DESCRIPTION
Текстовая версия протокола результатов более компактна и приятнее выглядит.

Для всех шаблонов отключил сортировку групп, дистанций и коллективов. У секретаря может быть своя логика в сортировке. Например, в справке комиссии по допуску Краснодарский край должен стоять выше Астраханской области. 

- Выравнивание числовых столбцов по правому краю. Так данные легче воспринимать
- Уменьшил ширину столбцов без потери читаемости
- Не писать "б/р", отставание и штраф в формате мм:сс (убрал лишний визуальный шум)
- Добавил настройку Разряд (разряд не всегда нужен)
- Поставил столбец Разряд перед годом рождения. ГР выровнен вправо, Разряд — влево и в предыдущем варианте столбцы слипались друг с другом, сейчас между столбцами появилось разряжение

TODO:
- Сделать то же самое для остальных протоколов
- Сделать то же самое для табличной версии
- Сделать проверку, что максимальный штраф и максимальное отставание меньше часа; в противном случае переходить на формат чч:мм:сс (или обрабатывать по-другому)