### PR TITLE
Fix broken test_duplicates

### DIFF
--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -1500,9 +1500,6 @@ msgstr "Использовать финиш как КП с кодом:"
 msgid "Ignore readout before start"
 msgstr "Игнорировать считывание до старта"
 
-msgid "Ignore readout before start"
-msgstr "Игнорировать считывание до старта"
-
 msgid "Did not start"
 msgstr "НЕ СТАРТ."
 


### PR DESCRIPTION
Падает test_duplicates из-за дубрирующейся строки _Ignore readout before start_. 

После удаления дубля тест выполняется.