### PR TITLE
Наработки для маркированной трассы со штрафными кругами

### DIFF
--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -669,26 +669,26 @@ msgstr "Режим начисления штрафа: штрафные круг�
 msgid "counting lap"
 msgstr "оценочный круг"
 
-msgid "Operating mode: evaluation point"
-msgstr "Режим работы: оценочный круг"
-
-msgid "Print number of penalty laps instead of splits"
-msgstr "При считывании печатается распечатка"
-
-msgid "when competitor reads out his card"
-msgstr "с количеством штрафных кругов"
+msgid ""
+"Operating mode: evaluation point\n"
+"Print the number of penalty laps instead of splits\n"
+"when a competitor reads out his card"
+msgstr ""
+"Режим работы: оценочный круг\n"
+"При считывании печатать распечатку\n"
+"с количеством штрафных кругов"
 
 msgid "lap station"
 msgstr "станция на штрафном круге"
 
-msgid "Station number on the penalty lap"
-msgstr "Номер станции на штрафном круге"
-
-msgid "Competitor must punch at station"
-msgstr "Спортсмен должен отметиться на станции"
-
-msgid "every time he/she passes a penalty lap"
-msgstr "при каждом прохождении штрафного круга"
+msgid ""
+"Station number on the penalty lap\n"
+"A competitor must punch at the station\n"
+"each time they pass the penalty lap"
+msgstr ""
+"Номер станции на штрафном круге\n"
+"Спортсмен должен отметиться на станции\n"
+"при каждом прохождении штрафного круга"
 
 msgid "scores off"
 msgstr "очки не рассчитываются"

--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -1545,9 +1545,6 @@ msgstr "СОШЕЛ"
 msgid "Disqualified"
 msgstr "ДИСКВ."
 
-msgid "Missing penalty lap"
-msgstr "Пропущен штрафной круг"
-
 msgid "laps"
 msgstr "кр."
 

--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -354,6 +354,9 @@ msgstr "Финиш"
 msgid "Penalty"
 msgstr "Штраф"
 
+msgid "Penalty laps"
+msgstr "Штрафные круги"
+
 msgid "Penalty legs"
 msgstr "Штраф, круги"
 
@@ -648,17 +651,44 @@ msgstr "Штраф за каждую просроченную минуту"
 msgid "no penalty"
 msgstr "штраф не начисляется"
 
+msgid "No penalty"
+msgstr "Штраф не начисляется"
+
 msgid "penalty time"
 msgstr "штрафное время"
+
+msgid "Penalty calculation mode: penalty time"
+msgstr "Режим начисления штрафа: штрафное время"
 
 msgid "penalty laps"
 msgstr "штрафные круги"
 
+msgid "Penalty calculation mode: penalty laps"
+msgstr "Режим начисления штрафа: штрафные круги"
+
 msgid "counting lap"
 msgstr "оценочный круг"
 
+msgid "Operating mode: evaluation point"
+msgstr "Режим работы: оценочный круг"
+
+msgid "Print number of penalty laps instead of splits"
+msgstr "При считывании печатается распечатка"
+
+msgid "when competitor reads out his card"
+msgstr "с количеством штрафных кругов"
+
 msgid "lap station"
 msgstr "станция на штрафном круге"
+
+msgid "Station number on the penalty lap"
+msgstr "Номер станции на штрафном круге"
+
+msgid "Competitor must punch at station"
+msgstr "Спортсмен должен отметиться на станции"
+
+msgid "every time he/she passes a penalty lap"
+msgstr "при каждом прохождении штрафного круга"
 
 msgid "scores off"
 msgstr "очки не рассчитываются"
@@ -1514,6 +1544,12 @@ msgstr "СОШЕЛ"
 
 msgid "Disqualified"
 msgstr "ДИСКВ."
+
+msgid "Missing penalty lap"
+msgstr "Пропущен штрафной круг"
+
+msgid "laps"
+msgstr "кр."
 
 msgid "contain"
 msgstr "содержит"

--- a/sportorg/gui/dialogs/result_edit.py
+++ b/sportorg/gui/dialogs/result_edit.py
@@ -289,6 +289,7 @@ class ResultEditDialog(QDialog):
             try:
                 ResultChecker.checking(result)
                 ResultChecker.calculate_penalty(result)
+                ResultChecker.checking(result)
                 if result.person and result.person.group:
                     GroupSplits(race(), result.person.group).generate(True)
             except ResultCheckerException as e:

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -457,7 +457,7 @@ class TimekeepingPropertiesDialog(QDialog):
         )
         mr_if_counting_lap = obj.get_setting('marked_route_if_counting_lap', False)
         mr_if_station_check = obj.get_setting('marked_route_if_station_check', False)
-        mr_station_code = obj.get_setting('marked_route_station_code', 80)
+        mr_station_code = obj.get_setting('marked_route_penalty_lap_station_code', 80)
         mr_if_dont_dsq_check = obj.get_setting('marked_route_dont_dsq', False)
         mr_if_max_penalty_by_cp = obj.get_setting(
             'marked_route_max_penalty_by_cp', False

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -204,8 +204,18 @@ class TimekeepingPropertiesDialog(QDialog):
         self.mr_laps_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_laps_radio)
         self.mr_counting_lap_check = QCheckBox(translate('counting lap'))
+        self.mr_counting_lap_check.setToolTip(
+            translate('Operating mode: evaluation point') + '\n' +
+            translate('Print number of penalty laps instead of splits') + '\n' +
+            translate('when competitor reads out his card'))
+        self.mr_counting_lap_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_counting_lap_check)
         self.mr_lap_station_check = QCheckBox(translate('lap station'))
+        self.mr_lap_station_check.setToolTip(
+            translate('Station number on the penalty lap') + '\n' +
+            translate('Competitor must punch at station') + '\n' +
+            translate('every time he/she passes a penalty lap'))
+        self.mr_lap_station_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_lap_station_edit = AdvSpinBox(max_width=50)
         self.mr_layout.addRow(self.mr_lap_station_check, self.mr_lap_station_edit)
         self.mr_dont_dqs_check = QCheckBox(translate("Don't disqualify"))
@@ -318,29 +328,28 @@ class TimekeepingPropertiesDialog(QDialog):
         self.chip_duplicate_box.setDisabled(mode)
 
     def penalty_calculation_mode(self):
-        self.mr_time_edit.setDisabled(not self.mr_time_radio.isChecked())
+        self.mr_time_edit.setDisabled(
+            not self.mr_time_radio.isChecked()
+        )
         self.mr_counting_lap_check.setDisabled(
-            not (
-                self.mr_laps_radio.isChecked()
-                and not self.mr_lap_station_check.isChecked()
-            )
+            not (self.mr_laps_radio.isChecked() and 
+                 not self.mr_lap_station_check.isChecked())
         )
         self.mr_lap_station_check.setDisabled(
-            not (
-                self.mr_laps_radio.isChecked()
-                and not self.mr_counting_lap_check.isChecked()
-            )
+            not (self.mr_laps_radio.isChecked() and
+                 not self.mr_counting_lap_check.isChecked())
         )
         self.mr_lap_station_edit.setDisabled(
-            not (
-                self.mr_laps_radio.isChecked() and self.mr_lap_station_check.isChecked()
-            )
+            not (self.mr_laps_radio.isChecked() and
+                 self.mr_lap_station_check.isChecked())
         )
         self.mr_dont_dqs_check.setDisabled(
-            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
+            not (self.mr_laps_radio.isChecked() or
+                 self.mr_time_radio.isChecked())
         )
         self.mr_max_penalty_by_cp.setDisabled(
-            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
+            not (self.mr_laps_radio.isChecked() or
+                 self.mr_time_radio.isChecked())
         )
 
     def set_values_from_model(self):

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -205,16 +205,22 @@ class TimekeepingPropertiesDialog(QDialog):
         self.mr_layout.addRow(self.mr_laps_radio)
         self.mr_counting_lap_check = QCheckBox(translate('counting lap'))
         self.mr_counting_lap_check.setToolTip(
-            translate('Operating mode: evaluation point') + '\n' +
-            translate('Print number of penalty laps instead of splits') + '\n' +
-            translate('when competitor reads out his card'))
+            translate('Operating mode: evaluation point')
+            + '\n'
+            + translate('Print number of penalty laps instead of splits')
+            + '\n'
+            + translate('when competitor reads out his card')
+        )
         self.mr_counting_lap_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_counting_lap_check)
         self.mr_lap_station_check = QCheckBox(translate('lap station'))
         self.mr_lap_station_check.setToolTip(
-            translate('Station number on the penalty lap') + '\n' +
-            translate('Competitor must punch at station') + '\n' +
-            translate('every time he/she passes a penalty lap'))
+            translate('Station number on the penalty lap')
+            + '\n'
+            + translate('Competitor must punch at station')
+            + '\n'
+            + translate('every time he/she passes a penalty lap')
+        )
         self.mr_lap_station_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_lap_station_edit = AdvSpinBox(max_width=50)
         self.mr_layout.addRow(self.mr_lap_station_check, self.mr_lap_station_edit)
@@ -328,28 +334,29 @@ class TimekeepingPropertiesDialog(QDialog):
         self.chip_duplicate_box.setDisabled(mode)
 
     def penalty_calculation_mode(self):
-        self.mr_time_edit.setDisabled(
-            not self.mr_time_radio.isChecked()
-        )
+        self.mr_time_edit.setDisabled(not self.mr_time_radio.isChecked())
         self.mr_counting_lap_check.setDisabled(
-            not (self.mr_laps_radio.isChecked() and 
-                 not self.mr_lap_station_check.isChecked())
+            not (
+                self.mr_laps_radio.isChecked()
+                and not self.mr_lap_station_check.isChecked()
+            )
         )
         self.mr_lap_station_check.setDisabled(
-            not (self.mr_laps_radio.isChecked() and
-                 not self.mr_counting_lap_check.isChecked())
+            not (
+                self.mr_laps_radio.isChecked()
+                and not self.mr_counting_lap_check.isChecked()
+            )
         )
         self.mr_lap_station_edit.setDisabled(
-            not (self.mr_laps_radio.isChecked() and
-                 self.mr_lap_station_check.isChecked())
+            not (
+                self.mr_laps_radio.isChecked() and self.mr_lap_station_check.isChecked()
+            )
         )
         self.mr_dont_dqs_check.setDisabled(
-            not (self.mr_laps_radio.isChecked() or
-                 self.mr_time_radio.isChecked())
+            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
         )
         self.mr_max_penalty_by_cp.setDisabled(
-            not (self.mr_laps_radio.isChecked() or
-                 self.mr_time_radio.isChecked())
+            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
         )
 
     def set_values_from_model(self):

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -205,21 +205,21 @@ class TimekeepingPropertiesDialog(QDialog):
         self.mr_layout.addRow(self.mr_laps_radio)
         self.mr_counting_lap_check = QCheckBox(translate('counting lap'))
         self.mr_counting_lap_check.setToolTip(
-            translate('Operating mode: evaluation point')
-            + '\n'
-            + translate('Print number of penalty laps instead of splits')
-            + '\n'
-            + translate('when competitor reads out his card')
+            translate(
+                'Operating mode: evaluation point\n'
+                'Print the number of penalty laps instead of splits\n'
+                'when a competitor reads out his card'
+            )
         )
         self.mr_counting_lap_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_counting_lap_check)
         self.mr_lap_station_check = QCheckBox(translate('lap station'))
         self.mr_lap_station_check.setToolTip(
-            translate('Station number on the penalty lap')
-            + '\n'
-            + translate('Competitor must punch at station')
-            + '\n'
-            + translate('every time he/she passes a penalty lap')
+            translate(
+                'Station number on the penalty lap\n'
+                'A competitor must punch at the station\n'
+                'each time they pass the penalty lap'
+            )
         )
         self.mr_lap_station_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_lap_station_edit = AdvSpinBox(max_width=50)

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -183,15 +183,25 @@ class TimekeepingPropertiesDialog(QDialog):
 
         self.result_proc_tab.setLayout(self.result_proc_layout)
 
-        # marked route settings
+        # marked route penalty calculation settings
         self.marked_route_tab = QWidget()
         self.mr_layout = QFormLayout()
         self.mr_off_radio = QRadioButton(translate('no penalty'))
+        self.mr_off_radio.setToolTip(translate('No penalty'))
+        self.mr_off_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_off_radio)
         self.mr_time_radio = QRadioButton(translate('penalty time'))
+        self.mr_time_radio.setToolTip(
+            translate('Penalty calculation mode: penalty time')
+        )
+        self.mr_time_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_time_edit = AdvTimeEdit(display_format=self.time_format)
         self.mr_layout.addRow(self.mr_time_radio, self.mr_time_edit)
         self.mr_laps_radio = QRadioButton(translate('penalty laps'))
+        self.mr_laps_radio.setToolTip(
+            translate('Penalty calculation mode: penalty laps')
+        )
+        self.mr_laps_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_laps_radio)
         self.mr_counting_lap_check = QCheckBox(translate('counting lap'))
         self.mr_layout.addRow(self.mr_counting_lap_check)
@@ -199,8 +209,10 @@ class TimekeepingPropertiesDialog(QDialog):
         self.mr_lap_station_edit = AdvSpinBox(max_width=50)
         self.mr_layout.addRow(self.mr_lap_station_check, self.mr_lap_station_edit)
         self.mr_dont_dqs_check = QCheckBox(translate("Don't disqualify"))
+        self.mr_dont_dqs_check.setToolTip(translate("Don't disqualify"))
         self.mr_layout.addRow(self.mr_dont_dqs_check)
         self.mr_max_penalty_by_cp = QCheckBox(translate('Max penalty = quantity of cp'))
+        self.mr_max_penalty_by_cp.setToolTip(translate('Max penalty = quantity of cp'))
         self.mr_layout.addRow(self.mr_max_penalty_by_cp)
         self.marked_route_tab.setLayout(self.mr_layout)
 
@@ -304,6 +316,32 @@ class TimekeepingPropertiesDialog(QDialog):
         self.finish_group_box.setDisabled(mode)
         self.chip_reading_box.setDisabled(mode)
         self.chip_duplicate_box.setDisabled(mode)
+
+    def penalty_calculation_mode(self):
+        self.mr_time_edit.setDisabled(not self.mr_time_radio.isChecked())
+        self.mr_counting_lap_check.setDisabled(
+            not (
+                self.mr_laps_radio.isChecked()
+                and not self.mr_lap_station_check.isChecked()
+            )
+        )
+        self.mr_lap_station_check.setDisabled(
+            not (
+                self.mr_laps_radio.isChecked()
+                and not self.mr_counting_lap_check.isChecked()
+            )
+        )
+        self.mr_lap_station_edit.setDisabled(
+            not (
+                self.mr_laps_radio.isChecked() and self.mr_lap_station_check.isChecked()
+            )
+        )
+        self.mr_dont_dqs_check.setDisabled(
+            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
+        )
+        self.mr_max_penalty_by_cp.setDisabled(
+            not (self.mr_laps_radio.isChecked() or self.mr_time_radio.isChecked())
+        )
 
     def set_values_from_model(self):
         cur_race = race()
@@ -417,7 +455,7 @@ class TimekeepingPropertiesDialog(QDialog):
         mr_penalty_time = OTime(
             msec=obj.get_setting('marked_route_penalty_time', 60000)
         )
-        mr_if_counting_lap = obj.get_setting('marked_route_if_counting_lap', True)
+        mr_if_counting_lap = obj.get_setting('marked_route_if_counting_lap', False)
         mr_if_station_check = obj.get_setting('marked_route_if_station_check', False)
         mr_station_code = obj.get_setting('marked_route_station_code', 80)
         mr_if_dont_dsq_check = obj.get_setting('marked_route_dont_dsq', False)
@@ -596,7 +634,7 @@ class TimekeepingPropertiesDialog(QDialog):
         obj.set_setting('marked_route_penalty_time', mr_penalty_time)
         obj.set_setting('marked_route_if_counting_lap', mr_if_counting_lap)
         obj.set_setting('marked_route_if_station_check', mr_if_station_check)
-        obj.set_setting('marked_route_station_code', mr_station_code)
+        obj.set_setting('marked_route_penalty_lap_station_code', mr_station_code)
         obj.set_setting('marked_route_dont_dsq', mr_if_dont_dsq)
         obj.set_setting('marked_route_max_penalty_by_cp', mr_if_max_penalty_by_cp)
 

--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -594,6 +594,7 @@ class PenaltyCalculationAction(Action, metaclass=ActionFactory):
         for result in race().results:
             if result.person:
                 ResultChecker.calculate_penalty(result)
+                ResultChecker.checking(result)
         logging.debug('Penalty calculation finish')
         ResultCalculation(race()).process_results()
         self.app.refresh()

--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -593,6 +593,7 @@ class PenaltyCalculationAction(Action, metaclass=ActionFactory):
         logging.debug('Penalty calculation start')
         for result in race().results:
             if result.person:
+                ResultChecker.checking(result)
                 ResultChecker.calculate_penalty(result)
                 ResultChecker.checking(result)
         logging.debug('Penalty calculation finish')

--- a/sportorg/libs/template/template.py
+++ b/sportorg/libs/template/template.py
@@ -31,19 +31,6 @@ def date(value, fmt=None):
     return dateutil.parser.parse(value).strftime(fmt)
 
 
-def plural(value, fmt=None):
-    if value is None:
-        return ''
-    if 5 <= abs(value) <= 19:
-        return 'ов'
-    elif abs(value) % 10 == 1:
-        return ''
-    elif abs(value) % 10 in (2, 3, 4):
-        return 'а'
-    else:
-        return 'ов'
-
-
 def finalize(thing):
     return thing if thing else ''
 
@@ -63,7 +50,6 @@ def get_text_from_template(searchpath: str, path: str, **kwargs):
     env.filters['tohhmmss'] = to_hhmmss
     env.filters['date'] = date
     env.policies['json.dumps_kwargs']['ensure_ascii'] = False
-    env.filters['plural'] = plural
     template = env.get_template(path)
 
     return template.render(**kwargs)

--- a/sportorg/libs/template/template.py
+++ b/sportorg/libs/template/template.py
@@ -31,6 +31,19 @@ def date(value, fmt=None):
     return dateutil.parser.parse(value).strftime(fmt)
 
 
+def plural(value, fmt=None):
+    if value is None:
+        return ''
+    if 5 <= abs(value) <= 19:
+        return 'ов'
+    elif abs(value) % 10 == 1:
+        return ''
+    elif abs(value) % 10 in (2, 3, 4):
+        return 'а'
+    else:
+        return 'ов'
+
+
 def finalize(thing):
     return thing if thing else ''
 
@@ -50,6 +63,7 @@ def get_text_from_template(searchpath: str, path: str, **kwargs):
     env.filters['tohhmmss'] = to_hhmmss
     env.filters['date'] = date
     env.policies['json.dumps_kwargs']['ensure_ascii'] = False
+    env.filters['plural'] = plural
     template = env.get_template(path)
 
     return template.render(**kwargs)

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -93,6 +93,7 @@ class ResultStatus(_TitleType):
     DID_NOT_ENTER = 14
     CANCELLED = 15
     RESTORED = 16
+    MISS_PENALTY_LAP = 17
 
 
 class Organization(Model):

--- a/sportorg/models/result/result_checker.py
+++ b/sportorg/models/result/result_checker.py
@@ -332,7 +332,7 @@ class ResultChecker:
 
         mr_if_counting_lap = obj.get_setting('marked_route_if_counting_lap', False)
         mr_if_station_check = obj.get_setting('marked_route_if_station_check', False)
-        mr_station_code = obj.get_setting('marked_route_station_code', 0)
+        mr_station_code = obj.get_setting('marked_route_penalty_lap_station_code', 0)
 
         if mr_if_station_check and int(mr_station_code) > 0:
             count_laps = 0

--- a/sportorg/models/result/result_checker.py
+++ b/sportorg/models/result/result_checker.py
@@ -255,9 +255,9 @@ class ResultChecker:
 
     @staticmethod
     def detach_penalty_laps2(splits, lap_station):
-        """Walkaround: извлекает отметки на штрафной станции.
-        Наивный метод, надо учитывать, что штрафные КП должны относиться
-        к пункту оценки, а не появляться из неочищенного чипа"""
+        '''Detaches penalty laps from the given list of splits
+        based on the provided lap station code.
+        '''
         if not splits:
             return [], []
         regular = [punch for punch in splits if int(punch.code) != lap_station]

--- a/sportorg/models/result/result_checker.py
+++ b/sportorg/models/result/result_checker.py
@@ -49,12 +49,15 @@ class ResultChecker:
             ResultStatus.OK,
             ResultStatus.MISSING_PUNCH,
             ResultStatus.OVERTIME,
+            ResultStatus.MISS_PENALTY_LAP,
         ]:
             result.status = ResultStatus.OK
             if not o.check_result(result):
                 result.status = ResultStatus.MISSING_PUNCH
                 result.status_comment = 'п.п.3.13.12.2'
 
+            elif not cls.check_penalty_laps(result):
+                result.status = ResultStatus.MISS_PENALTY_LAP
             elif result.person.group and result.person.group.max_time.to_msec():
                 if result.get_result_otime() > result.person.group.max_time:
                     if race().get_setting('result_processing_mode', 'time') == 'time':
@@ -72,7 +75,7 @@ class ResultChecker:
                 ResultChecker.calculate_penalty(result)
 
     @staticmethod
-    def calculate_penalty(result):
+    def calculate_penalty(result: Result):
         mode = race().get_setting('marked_route_mode', 'off')
         if mode == 'off':
             return
@@ -89,16 +92,19 @@ class ResultChecker:
             return
 
         controls = course.controls
+        splits = result.splits
+
+        if mode == 'laps' and race().get_setting('marked_route_if_station_check'):
+            lap_station = race().get_setting('marked_route_penalty_lap_station_code')
+            splits, _ = ResultChecker.detach_penalty_laps2(splits, lap_station)
 
         if race().get_setting('marked_route_dont_dsq', False):
             # free order, don't penalty for extra cp
-            penalty = ResultChecker.penalty_calculation_free_order(
-                result.splits, controls
-            )
+            penalty = ResultChecker.penalty_calculation_free_order(splits, controls)
         else:
             # marked route with penalty
             penalty = ResultChecker.penalty_calculation(
-                result.splits, controls, check_existence=True
+                splits, controls, check_existence=True
             )
 
         if race().get_setting('marked_route_max_penalty_by_cp', False):
@@ -167,9 +173,12 @@ class ResultChecker:
                                                      // returns 1 if check_existence=True
         ```
         """
+
         user_array = [i.code for i in splits]
         origin_array = [i.get_number_code() for i in controls]
         res = 0
+
+        # может дать 0 штрафа при мусоре в чипе
         if check_existence and len(user_array) < len(origin_array):
             # add 1 penalty score for missing points
             res = len(origin_array) - len(user_array)
@@ -231,6 +240,48 @@ class ResultChecker:
         res += max(len(controls) - correct_count, 0)
 
         return res
+
+    @staticmethod
+    def detach_penalty_laps(splits, lap_station):
+        if not splits:
+            return [], []
+        for idx, punch in enumerate(reversed(splits)):
+            if int(punch.code) != lap_station:
+                break
+        else:
+            idx = len(splits)
+        idx = len(splits) - idx
+        return splits[:idx], splits[idx:]
+
+    @staticmethod
+    def detach_penalty_laps2(splits, lap_station):
+        """Walkaround: извлекает отметки на штрафной станции.
+        Наивный метод, надо учитывать, что штрафные КП должны относиться
+        к пункту оценки, а не появляться из неочищенного чипа"""
+        if not splits:
+            return [], []
+        regular = [punch for punch in splits if int(punch.code) != lap_station]
+        penalty = [punch for punch in splits if int(punch.code) == lap_station]
+        return regular, penalty
+
+    @staticmethod
+    def check_penalty_laps(result):
+        assert isinstance(result, Result)
+
+        mode = race().get_setting('marked_route_mode', 'off')
+        check_laps = race().get_setting('marked_route_if_station_check')
+
+        if mode == 'laps' and check_laps:
+            lap_station = race().get_setting('marked_route_penalty_lap_station_code')
+            _, penalty_laps = ResultChecker.detach_penalty_laps2(
+                result.splits, lap_station
+            )
+            num_penalty_laps = len(penalty_laps)
+
+            if num_penalty_laps < result.penalty_laps:
+                return False
+
+        return True
 
     @staticmethod
     def get_control_score(code):

--- a/sportorg/modules/sportident/result_generation.py
+++ b/sportorg/modules/sportident/result_generation.py
@@ -151,6 +151,7 @@ class ResultSportidentGeneration:
             if existing_res.merge_with(self._result):
                 # existing result changed, recalculate group results and printout
                 self._result = existing_res
+                ResultChecker.checking(self._result)
                 ResultChecker.calculate_penalty(self._result)
                 ResultChecker.checking(self._result)
                 self.popup_result(self._result)
@@ -202,6 +203,7 @@ class ResultSportidentGeneration:
             try:
                 ResultChecker.checking(self._result)
                 ResultChecker.calculate_penalty(self._result)
+                ResultChecker.checking(self._result)
             except ResultCheckerException as e:
                 logging.error(str(e))
 

--- a/templates/split/1_split_printout.html
+++ b/templates/split/1_split_printout.html
@@ -175,6 +175,11 @@
         {% endfor %}
         </table>
         <br> Финиш: {{result.finish_msec|tohhmmss}} {{result.speed}}
+        {% if race['settings'].get('marked_route_mode', 'off') == 'laps' %}
+        <br> Штраф: {{result.penalty_laps}} круг{{result.penalty_laps|plural}}
+        {% elif race['settings'].get('marked_route_mode', 'off') == 'time' %}
+        <br> Штраф: {{result.penalty_time|tohhmmss}}
+        {% endif %}
         <br> Результат: {{result.result}}
         {% if result.place > 0 %}
             <br> Место: {{result.place}} из {{group.count_finished}} (всего {{group.count_person}})

--- a/templates/split/1_split_printout.html
+++ b/templates/split/1_split_printout.html
@@ -176,7 +176,7 @@
         </table>
         <br> Финиш: {{result.finish_msec|tohhmmss}} {{result.speed}}
         {% if race['settings'].get('marked_route_mode', 'off') == 'laps' %}
-        <br> Штраф: {{result.penalty_laps}} круг{{result.penalty_laps|plural}}
+        <br> Штрафных кругов: {{result.penalty_laps}}
         {% elif race['settings'].get('marked_route_mode', 'off') == 'time' %}
         <br> Штраф: {{result.penalty_time|tohhmmss}}
         {% endif %}

--- a/templates/split/2_marked_route_penalty_A5.html
+++ b/templates/split/2_marked_route_penalty_A5.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- A5 paper with portrait orientation -->
+<head>
+    <meta charset="UTF-8">
+    <title>{{name}} Split</title>
+    {% raw %}
+    <style>
+        p {
+            font-family: Arial, Helvetica, sans-serif;
+            font-weight: bold;
+            text-align: center;
+        }
+        .penalty-digit {
+            font-size: 150pt;
+        }
+        .penalty-text {
+            font-size: 90pt;
+        }
+        .penalty-outer {
+            font-size: 30pt;
+        }
+        hr {
+            width: 300%;
+            border: dashed;
+        }
+    </style>
+    {% endraw %}
+</head>
+
+<body>
+    <code>
+        <p class="penalty-outer">&nbsp;</p>
+        <p class="penalty-inner">
+            <span class="penalty-text">№</span>
+            <span class="penalty-digit">{{person.bib}}</span>
+        </p>
+        <p class="penalty-outer">&nbsp;</p>
+        <hr>
+        <p class="penalty-outer">&nbsp;</p>
+        <p class="penalty-inner">
+            <span class="penalty-digit">{{result.penalty_laps}}</span>
+            <span class="penalty-text">кр.</span>
+        </p>
+    </code>
+</body>
+
+</html>

--- a/templates/split/3_marked_route_penalty_80mm.html
+++ b/templates/split/3_marked_route_penalty_80mm.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- A5 paper with portrait orientation -->
+<head>
+    <meta charset="UTF-8">
+    <title>{{name}} Split</title>
+    {% raw %}
+    <style>
+        p {
+            font-family: Arial, Helvetica, sans-serif;
+            font-weight: bold;
+            text-align: left;
+            padding-top: 250px;
+
+        }
+        .penalty-digit {
+            font-size: 96pt;
+        }
+        .penalty-text {
+            font-size: 32pt;
+        }
+        .penalty-outer {
+            font-size: 60pt;
+            font-weight: 100;
+        }
+        hr {
+            width: 300%;
+            border: dashed;
+        }
+        div {
+        }
+    </style>
+    {% endraw %}
+</head>
+
+<body>
+    <code>
+        <div><div>
+        <p class="penalty-inner">
+            <span class="penalty-text">№</span>
+            <span class="penalty-digit">{{person.bib}}</span>
+        </p>
+        <div><div>
+        <hr>
+        <p class="penalty-outer">&nbsp;</p>
+        <p class="penalty-inner">
+            <span class="penalty-digit">{% if result.penalty_laps %}{{result.penalty_laps}}{% else %}0{% endif %}</span>
+            <span class="penalty-text">кр.</span>
+        </p>
+        <div><div>
+    </code>
+</body>
+
+</html>

--- a/tests/test_penalty_checking.py
+++ b/tests/test_penalty_checking.py
@@ -63,106 +63,64 @@ def test_marked_route_yes_no():
     отметиться в станции НЕТ. За неправильную отметку спортсмен получает штраф.
     За отсутствующую отметку спортсмен должен быть дисквалифицирован.
     """
+    # fmt: off
     create_race()
     race().set_setting('marked_route_mode', 'time')
 
     # Отметка ок, без штрафа
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 41, 51, 100],
-        penalty=0,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31,          41,          51,         100], penalty=0)
 
     # Отметка ок, 1 штраф - неверный выбор на одном КП
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 42, 51, 100],
-        penalty=1,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31,          42,          51,         100], penalty=1)
 
     # Отметка ок, 3 штрафа - неверный выбор на трёх КП
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[32, 42, 52, 100],
-        penalty=3,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 32,          42,          52,         100], penalty=3)
 
     # Отметка ок, 0 штрафа - лишняя отметка на одном истинном КП
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 31, 41, 51, 100],
-        penalty=0,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31, 31,      41,          51,         100], penalty=0)
 
     # Отметка ок, 1 штраф - лишняя отметка на одном ложном КП
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 41, 52, 52, 100],
-        penalty=1,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31,          41,          52, 52,     100], penalty=1)
 
     # Отметка ок, 1 штраф - отметка на обоих станциях на одном КП
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[32, 31, 41, 51, 100],
-        penalty=1,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 32, 31,      41,          51,         100], penalty=1)
 
     # Дисквалифицирован, 1 штраф - отсутствует отметка на одном КП
-    assert dsq(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 51, 100],
-        penalty=1,
-    )
+    assert dsq(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31,                       51,         100], penalty=1)
 
     # Дисквалифицирован, 1 штраф - отсутствует отметка на последнем КП100
-    assert dsq(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[
-            31,
-            41,
-            51,
-        ],
-        penalty=1,
-    )
+    assert dsq(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31,          41,          51,            ], penalty=1)
 
     # Дисквалифицирован, 4 штрафа - пустой чип
-    assert dsq(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100], splits=[], penalty=4
-    )
+    assert dsq(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[                                          ], penalty=4)
 
     # Отметка ок, 0 штрафа - отметка на КП, которого нет на карте
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 75, 41, 51, 100],
-        penalty=0,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31, 75,      41,          51,         100], penalty=0)
 
     # Отметка ок, 0 штрафа - отметка на КП, которого нет на карте
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[31, 75, 41, 51, 100],
-        penalty=0,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 31, 75,      41,          51,         100], penalty=0)
 
     # Отметка ок, 0 штрафа - неочищенный чип НЕ содержит часть дистанции
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[70, 71, 72, 73, 31, 41, 51, 100],
-        penalty=0,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 70, 71, 72, 73,   31, 41, 51,         100], penalty=0)
 
     # Отметка ок, 1 штраф - неочищенный чип содержит часть дистанции
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[40, 41, 42, 43, 31, 41, 51, 100],
-        penalty=1,
-    )
-    assert ok(
-        course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
-        splits=[40, 41, 42, 43, 31, 42, 51, 100],
-        penalty=1,
-    )
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 40, 41, 42, 43,   31, 41, 51,         100], penalty=1)
+    assert  ok(course=['31(31,32)', '41(41,42)', '51(51,52)', 100],
+               splits=[ 40, 41, 42, 43,   31, 42, 51,         100], penalty=1)
+    # fmt: on
 
 
 def test_penalty_calculation_function():
@@ -172,118 +130,124 @@ def test_penalty_calculation_function():
     так как с параметрами penalty_calculation(<...>, check_existence=False)
     эта функция нигде не вызывается.
     """
+    # fmt: off
     create_race()
     race().set_setting('marked_route_mode', 'time')
 
     # return quantity of incorrect or duplicated punches, order is ignored
     # origin: 31,41,51; athlete: 31,41,51; result:0
-    assert ok(course=[31, 41, 51], splits=[31, 41, 51], penalty=0)
+    assert  ok(course=[31, 41, 51],
+               splits=[31, 41, 51], penalty=0)
 
     # origin: 31,41,51; athlete: 31; result:0
     # check_existence=False
     assert 0 == ResultChecker.penalty_calculation(
         splits=make_splits([31]),
-        controls=make_course_controls([31, 41, 51]),
-        check_existence=False,
-    )
+        controls=make_course_controls([31, 41, 51]), check_existence=False)
 
     # origin: 31,41,51; athlete: 31; result:2
     # check_existence=True
-    assert dsq(
-        course=[31, 41, 51],
-        splits=[
-            31,
-        ],
-        penalty=2,
-    )
+    assert dsq(course=[31, 41, 51],
+               splits=[31,       ], penalty=2)
 
     # origin: 31,41,51; athlete: 41,31,51; result:0
-    assert dsq(course=[31, 41, 51], splits=[41, 31, 51], penalty=0)
+    assert dsq(course=[31, 41, 51],
+               splits=[41, 31, 51], penalty=0)
 
     # origin: 31,41,51; athlete: 41,31,51; result:0
-    assert dsq(course=[31, 41, 51], splits=[41, 31, 51], penalty=0)
+    assert dsq(course=[31, 41, 51],
+               splits=[41, 31, 51], penalty=0)
 
     # origin: 31,41,51; athlete: 31,42,51; result:1
-    assert dsq(course=[31, 41, 51], splits=[31, 42, 51], penalty=1)
+    assert dsq(course=[31, 41, 51],
+               splits=[31, 42, 51], penalty=1)
 
     # origin: 31,41,51; athlete: 31,41,51,52; result:1
-    assert ok(course=[31, 41, 51], splits=[31, 41, 51, 52], penalty=1)
+    assert  ok(course=[31, 41, 51],
+               splits=[31, 41, 51, 52], penalty=1)
 
     # origin: 31,41,51; athlete: 31,42,51,52; result:2
-    assert dsq(course=[31, 41, 51], splits=[31, 42, 51, 52], penalty=2)
+    assert dsq(course=[31, 41, 51],
+               splits=[31, 42, 51, 52], penalty=2)
 
     # origin: 31,41,51; athlete: 31,31,41,51; result:1
-    assert ok(course=[31, 41, 51], splits=[31, 31, 41, 51], penalty=1)
+    assert  ok(course=[31, 41, 51],
+               splits=[31, 31, 41, 51], penalty=1)
 
     # origin: 31,41,51; athlete: 31,41,51,51; result:1
-    assert ok(course=[31, 41, 51], splits=[31, 41, 51, 51], penalty=1)
+    assert  ok(course=[31, 41, 51],
+               splits=[31, 41, 51, 51], penalty=1)
 
     # origin: 31,41,51; athlete: 32,42,52; result:3
-    assert dsq(course=[31, 41, 51], splits=[32, 42, 52], penalty=3)
+    assert dsq(course=[31, 41, 51],
+               splits=[32, 42, 52], penalty=3)
 
     # origin: 31,41,51; athlete: 31,41,51,61,71,81,91; result:4
-    assert ok(course=[31, 41, 51], splits=[31, 41, 51, 61, 71, 81, 91], penalty=4)
+    assert  ok(course=[31, 41, 51],
+               splits=[31, 41, 51, 61, 71, 81, 91], penalty=4)
 
     # origin: 31,41,51; athlete: 31,41,52,61,71,81,91; result:5
-    assert dsq(course=[31, 41, 51], splits=[31, 41, 52, 61, 71, 81, 91], penalty=5)
+    assert dsq(course=[31, 41, 51],
+               splits=[31, 41, 52, 61, 71, 81, 91], penalty=5)
 
     # origin: 31,41,51; athlete: 51,61,71,81,91,31,41; result:4
-    assert dsq(course=[31, 41, 51], splits=[51, 61, 71, 81, 91, 31, 41], penalty=4)
+    assert dsq(course=[31, 41, 51],
+               splits=[51, 61, 71, 81, 91, 31, 41], penalty=4)
 
     # origin: 31,41,51; athlete: 51,61,71,81,91,32,41; result:5
-    assert dsq(course=[31, 41, 51], splits=[51, 61, 71, 81, 91, 32, 41], penalty=5)
+    assert dsq(course=[31, 41, 51],
+               splits=[51, 61, 71, 81, 91, 32, 41], penalty=5)
 
     # origin: 31,41,51; athlete: 51,61,71,81,91,32,42; result:6
-    assert dsq(course=[31, 41, 51], splits=[51, 61, 71, 81, 91, 32, 42], penalty=6)
+    assert dsq(course=[31, 41, 51],
+               splits=[51, 61, 71, 81, 91, 32, 42], penalty=6)
 
     # origin: 31,41,51; athlete: 52,61,71,81,91,32,42; result:7
-    assert dsq(course=[31, 41, 51], splits=[52, 61, 71, 81, 91, 32, 42], penalty=7)
+    assert dsq(course=[31, 41, 51],
+               splits=[52, 61, 71, 81, 91, 32, 42], penalty=7)
 
     # origin: 31,41,51; athlete: no punches; result:0
     # check_existence=False
     assert 0 == ResultChecker.penalty_calculation(
         splits=make_splits([]),
-        controls=make_course_controls([31, 41, 51]),
-        check_existence=False,
-    )
+        controls=make_course_controls([31, 41, 51]), check_existence=False)
 
     # origin: 31,41,51; athlete: no punches; result:3
     # check_existence=True
-    assert dsq(course=[31, 41, 51], splits=[], penalty=3)
+    assert dsq(course=[31, 41, 51],
+               splits=[], penalty=3)
 
     # wildcard support for free order
     # origin: *,*,* athlete: 31; result:2
     # check_existence=False
     assert 0 == ResultChecker.penalty_calculation(
         splits=make_splits([31]),
-        controls=make_course_controls(['*', '*', '*']),
-        check_existence=False,
-    )
+        controls=make_course_controls(['*', '*', '*']), check_existence=False)
 
     # check_existence=True
-    assert dsq(course=['*', '*', '*'], splits=[31], penalty=2)
+    assert dsq(course=['*', '*', '*'],
+               splits=[31], penalty=2)
 
     # origin: *,*,* athlete: 31,31; result:2 //wrong
     # check_existence=False
     assert 0 == ResultChecker.penalty_calculation(
         splits=make_splits([31, 31]),
-        controls=make_course_controls(['*', '*', '*']),
-        check_existence=False,
-    )
+        controls=make_course_controls(['*', '*', '*']), check_existence=False)
 
     # check_existence=True
-    assert dsq(course=['*', '*', '*'], splits=[31, 31], penalty=1)
+    assert dsq(course=['*', '*', '*'],
+               splits=[31, 31], penalty=1)
 
     # origin: *,*,* athlete: 31,31,31,31; result:3 //wrong
     # check_existence=False
     assert 1 == ResultChecker.penalty_calculation(
         splits=make_splits([31, 31, 31, 31]),
-        controls=make_course_controls(['*', '*', '*']),
-        check_existence=False,
-    )
+        controls=make_course_controls(['*', '*', '*']), check_existence=False)
 
     # check_existence=True
-    assert dsq(course=['*', '*', '*'], splits=[31, 31, 31, 31], penalty=1)
+    assert dsq(course=['*', '*', '*'],
+               splits=[31, 31, 31, 31], penalty=1)
+    # fmt: on
 
 
 def test_non_obvious_behavior():
@@ -304,6 +268,11 @@ def test_non_obvious_behavior():
     assert dsq(course=['31', '41(41,42)'], splits=[41], penalty=1)
     assert dsq(course=['31', '41(41,42)'], splits=[39, 41], penalty=0)
     assert dsq(course=['31', '41(41,42)'], splits=[31, 49], penalty=0)
+
+    # Различные способы задания дистанции приводят к различному
+    # начислению штрафа за лишние отметки
+    assert ok(course=['31', '41'], splits=[31, 77, 41], penalty=1)
+    assert ok(course=['31', '41(41,42)'], splits=[31, 77, 41], penalty=0)
 
 
 def ok(

--- a/tests/test_penalty_checking.py
+++ b/tests/test_penalty_checking.py
@@ -28,8 +28,8 @@ from sportorg.models.result.result_checker import ResultChecker
 #       default value: marked_route_if_counting_lap = True
 # marked_route_if_station_check [bool] - режим проверки количества пройденных штрафных кругов
 #       default value: marked_route_if_station_check = False
-# marked_route_station_code [int] - номер станции на штрафном круге
-#       default value: marked_route_station_code = 80
+# marked_route_penalty_lap_station_code [int] - номер станции на штрафном круге
+#       default value: marked_route_penalty_lap_station_code = 80
 # marked_route_dont_dsq [bool] - дисквалифицировать ли спортсмена за пропущенные КП
 #   True - проверяет функцией penalty_calculation_free_order()
 #   False - проверяет функцией penalty_calculation(<...>, check_existence=True)


### PR DESCRIPTION
Мои наработки для маркировки со штрафными кругами (на пункте оценки печатается штраф, спортсмен проезжает требуемое количество штрафных кругов, отмечаясь на станции, может быть дисквалифицирован если проехал меньше, чем надо). Работу над проверкой маркировки параллельно вёл @sergeikobelev и его изменения попали в master. Соответственно, часть моих изменений перестали быть актуальными.

* `Настройки хронометража` -> `Штраф`. Переключение настроек в активное / не активное состояние в зависимости от выбранных настроек
* `Настройки хронометража` -> `Штраф`. Добавлены всплывающие подсказки (ToolTip) к некоторым настройкам
* Добавлен `ResultStatus.MISS_PENALTY_LAP` (пп4.6.12.7 # не прошел назначенное число штрафных кругов)
* `check_penalty_laps()` — проверка количества штрафных кругов. Сравнивает штраф на маркировке и количество отметок в штрафной станции
* `detach_penalty_laps()`, `detach_penalty_laps2()` — разделение сплита на два массива: отметки на дистанции и отметки на станции на штрафном круге
* Схема {`checking()` -> `calculate_penalty()` -> `checking()`} в нескольких местах: после первой проверки в сплит участника записываются отметки правильно / неправильно, по которым начисляется штраф; во второй проверке проверяется количество пройденных штрафных кругов
* Печать штрафа на пункте оценки (номер / штраф) через `win32print`
* `2_marked_route_penalty_A5.html` — шаблон для печати штрафа на пункте оценки (номер / штраф) для термоленты 80мм
* `3_marked_route_penalty_80mm.html` — шаблон для печати штрафа на пункте оценки (номер / штраф) на бумаге A5 (лазерный принтер)
* В шаблон для печати сплитов `1_split_printout.html` добавлена печать штрафного времени и штрафных кругов.
* `test_penalty_checking.py` — тесты для начисления штрафа
* Существующие функции для начисления штрафа (`penalty_calculation()` и `penalty_calculation_free_order()`) не менял.

Тестами охвачена проверка штрафа на дистанции. Постарался рассмотреть как можно больше разных случаев. Сомнительные (с моей точки зрения) моменты выделил в test_non_obvious_behavior(). До тестов на проверку количества штрафных кругов не добрался. Для удобства отладки, к тестам добавил информационные сообщения на случай провала: вывод сплитов и курсов, сколько штрафа ожидается и сколько начислено.

## Изменения Сергея Кобелева

Разработка велась в ветке `work`, параллельно с другими изменениями. Изменения влиты в `master` 13 июля.  Пробую перечислить отдельные коммиты. 

### Modification of courses for marked route (Russian event type with deсision points)
[7 марта](https://github.com/sportorg/pysport/commit/fb5294fdcf5a75fe9f0f7ce2b530d9499f1a6020)

Добавлено диалоговое окно Подготовка к старту -> Изменение дистанций для маркировки — для создания курсов маркировки: `31` -> `31(31,131)`

### Check penalty legs visiting
[7 марта](https://github.com/sportorg/pysport/commit/26a396e03321478a02b486ef905301e6d4ff466c), branch [marked_route_lap_control](https://github.com/sportorg/pysport/tree/marked_route_lap_control)

Добавлена функция `marked_route_check_penalty_laps()`. Считает количество отметок на станции на штрафном круге и сравнивает с начисленным штрафом. Отсутствует проверка, чтобы штрафные круги обязательно были в конце дистанции. 

По всей видимости, предполагается, что за лишние отметки штраф начисляться не будет.

Смущает часть: `if mr_if_counting_lap: count_laps = -1`. Возможно, частный случай, когда отметка на штрафном круге совмещена с последним КП. Я обычно прошу, чтобы станцию отметки ставили в дальней части штрафного круга, тогда -1 не нужен.

Спортсмен снимается со статусом `ResultStatus.MISSING_PUNCH` (как и при обычной неправильной отметки на заданке) и с комментарием `п.п.4.6.12.7` (не прошел назначенное число штрафных кругов).

### Marked route reports
[10 марта](https://github.com/sportorg/pysport/commit/36ed6e40b99e1c493dd457d0ab1a5045aed9f53e), branch [marked_route_reports](https://github.com/sportorg/pysport/tree/marked_route_reports)

Добавлены шаблоны:
* `1_маркировка_с_изображением.html` и `1_сплиты_маркировка_только_штраф.html` — сплиты для маркировки
* `2_маркировка_WO.html` и `2_маркировка_номер_и_штраф.html` — распечатки для пункта оценки: номер участника и штраф.
* `9_официальный_протокол_штраф_круги_word.docx` и `9_официальный_протокол_штраф_минуты_word.docx` — шаблоны результатов для Word

### Check result before penalty calculation. Prevent negative penalty (23:59:00 for -1)
[23 марта](https://github.com/sportorg/pysport/commit/8c06393b0655e82da0ff35e14d525e7aec179f09), branch [penalty_bug](https://github.com/sportorg/pysport/tree/penalty_bug)

Проверка штрафа перенесена после проверки правильности прохождения. Штраф не может быть отрицательным.

### Disqualify people at file open / event change
[23 марта](https://github.com/sportorg/pysport/commit/24c668f290a9ddd3e78df73c3367a95f930c04a1), branch [marked_route_dsq_on_file_open](https://github.com/sportorg/pysport/tree/marked_route_dsq_on_file_open)

Проверка штрафа и снятие спортсменов за не прохождение штрафных кругов происходит при старте спорторга.

### Penalty calculation optimization on file open / import / event change
[23 марта](https://github.com/sportorg/pysport/commit/4167ea01f5e248e579de377d3f0c9098ddcc5cf4), branch [penalty_calculation_optimization](https://github.com/sportorg/pysport/tree/penalty_calculation_optimization)

Отменён предыдущий коммит, проверка штрафа происходит в другом месте.

### New mode for time penalty - add penalty for extra controls
[29 марта](https://github.com/sportorg/pysport/commit/4167ea01f5e248e579de377d3f0c9098ddcc5cf4), branch [penalty_for_extra_cp](https://github.com/sportorg/pysport/tree/penalty_for_extra_cp)

!!! ветка не влита в `master` !!!

Добавлен режим начисления штрафа за лишние КП. Не знаю, как работает, не разбирался.

Изменено диалоговое окно `Настройки хронометража` -> `Расчёт штрафа из сплитов`. При разных комбинациях настроек другие настройки пропадают. С первого взгляда выглядит неудобно. Логичнее, чтобы оставались видны, но деактивировались, в своей версии сделал таким способом. 

### Version 1.6 release. Sum places - was inaccurate copy-pasted from sum scores. Word templates - new ranking places, macro for ranking replaced with direct realisation (Jinja2 works quite instable).
[24 мая](https://github.com/sportorg/pysport/commit/114e131c0b4251bb494cc9e08e7d91f6ba4cbe57), branch [penalty_laps_printout](https://github.com/sportorg/pysport/tree/penalty_laps_printout)

Исправлена неточность при печати штрафа в распечатке через `win32print`. 

### penalty_laps_printout and some templates
[24 мая](https://github.com/sportorg/pysport/commit/37bac877eb3b26bb9737a35d95c150d9f5d89d75)

Не содержится изменений, связанных с маркировкой.

Печать штрафа и штрафных кругов в сплитах через win32print. Ветка интегрирована в master. 

Эти ветки влиты в master, можно удалять: `marked_route_dsq_on_file_open`, `penalty_calculation_optimization`, `penalty_bug`, `marked_route_reports`, `marked_route_lap_control`. Эта ветка ещё не влита в master: `penalty_for_extra_cp`
