### PR TITLE
fix: shorter tab titles in the settings window

### DIFF
--- a/languages/en_US/LC_MESSAGES/sportorg.po
+++ b/languages/en_US/LC_MESSAGES/sportorg.po
@@ -73,3 +73,15 @@ msgstr "Penalty legs"
 
 msgid "Mf"
 msgstr "MF"
+
+msgid "SPORTident (Sportiduino, ...) settings"
+msgstr "Control cards"
+
+msgid "Result processing"
+msgstr "Result"
+
+msgid "Penalty calculation"
+msgstr "Penalty"
+
+msgid "Time settings"
+msgstr "Time"

--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -712,10 +712,10 @@ msgid "> 24"
 msgstr "> 24 часов"
 
 msgid "SPORTident (Sportiduino, ...) settings"
-msgstr "Настройки  SPORTident (Sportiduino, ...)"
+msgstr "Чипы"
 
 msgid "Result processing"
-msgstr "Определение результата"
+msgstr "Результат"
 
 msgid "Team results"
 msgstr "Командные результаты"
@@ -724,10 +724,10 @@ msgid "Scores"
 msgstr "Очки"
 
 msgid "Penalty calculation"
-msgstr "Расчет штрафа из сплитов"
+msgstr "Штраф"
 
 msgid "Time settings"
-msgstr "Настройки времени"
+msgstr "Время"
 
 msgid "Save file before exit?"
 msgstr "Сохранить изменения в файле?"


### PR DESCRIPTION
Короткие названия вкладок в окне Опции -> Настройки хронометража. 

В текущей версии Спорторга чтобы попасть во вкладку `Очки` или `Расчет штрафа из сплитов`, нужно либо скроллить вкладки, либо увеличивать размер окна. 

С короткими названиями все вкладки помещаются в окно. Достаточно одного клика, чтобы попасть на нужную вкладку.

Изменение английского перевода вместо изменения оригинальной строки в timekeeping_properties.py — чтобы не было повтора строки "Result".

![image](https://github.com/sportorg/pysport/assets/31531412/bc81305a-6bf2-4acd-bb8d-dba470d09d5e)
