### PR TITLE
docs: actual run from source tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Get Started
 
-### Prepare
+### Preparation
 
 SportOrg runs on Python 3.8 for compatibility with Windows 7. Latest Python 3.8 release with binary installers is [Python 3.8.10](https://www.python.org/downloads/release/python-3810/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,46 @@
 
 ## Get Started
 
-```
-python3.8 -m venv .venv
-```
+### Подготовка
+
+SportOrg runs on Python 3.8 for compatibility with Windows 7. Latest Python 3.8 release with binary installers is [Python 3.8.10](https://www.python.org/downloads/release/python-3810/).
+
+During development, the [poetry](https://python-poetry.org/) and [poe](https://poethepoet.natn.io/) tools are used. The preferred method for installing these utilities is [pipx](https://pipx.pypa.io/). 
+
+It may be necessary to restart the terminal window during the installation process to update the `PATH` environment variable.
 
 ```
-pip install poetry
+pip install pipx
+pipx ensurepath
+pipx install poetry
+pipx install poethepoet
+```
+
+### Create virtual environment
+
+Get pysport project.
+
+```
+git clone https://github.com/sportorg/pysport.git
+cd pysport
+```
+
+If multiple versions of Python are installed, it is necessary to specify the path to the Python 3.8 executable file.
+
+```
+poetry env use /full/path/to/python3.8
+```
+
+Install requirements.
+
+```
 poetry install
 poetry install -E win  # for Windows
 ```
 
 Add `DEBUG=True` to `.env` file or `cp .env.example .env`
+
+### Run SportOrg
 
 ```
 poe run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Get Started
 
-### Подготовка
+### Prepare
 
 SportOrg runs on Python 3.8 for compatibility with Windows 7. Latest Python 3.8 release with binary installers is [Python 3.8.10](https://www.python.org/downloads/release/python-3810/).
 
@@ -17,7 +17,7 @@ pipx install poetry
 pipx install poethepoet
 ```
 
-### Create virtual environment
+### Create Virtual Environment
 
 Get pysport project.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@
 
 Sportorg is a comprehensive software solution developed in Python that streamlines the organization and execution of orienteering competitions. Orienteering is a sport that challenges participants to navigate through unfamiliar terrain using only a map and compass, testing their navigation and decision-making skills. This software aims to enhance the experience for both event organizers and participants by providing a user-friendly platform to manage various aspects of orienteering competitions.
 
+## Run from source
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Screenshots
+
 ![Mainwindow sportorg](img/mainwindow.png)
 
 ![Dialogedit sportorg](img/dialogedit.png)
+
 ![Bibprintout sportorg](img/bibprintout.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,4 +120,7 @@ cmd = "python -m sportorg.language"
 
 [tool.poe.tasks.run]
 help = "Run"
-cmd = "python SportOrg.pyw"
+sequence = [
+    {ref = "generate-mo"},
+    {cmd = "python SportOrg.pyw"}
+]


### PR DESCRIPTION
Актуализировал руководство по настройке окружения и запуску SportOrg из исходного кода. 

Проверил на чистой Windows 10, в том числе и с уже установленным более свежим python (возможно, нужно более акцентированно написать о необходимости установки python 3.8). Могут возникнуть проблемы с установкой poetry и poe, если системный python установлен через Microsoft Store — он не прописывает себя в переменной окружения PATH, с терминалом взаимодействует как-то по-другому.

В `pyproject.toml` задание `poe run` добавил создание mo-файлов, без них SportOrg падает с ошибкой.

Английский не родной. Возможно, в тексте есть ошибки.