### PR TITLE
feat: add does-not-contain action to the filter

### DIFF
--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -1551,6 +1551,9 @@ msgstr "кр."
 msgid "contain"
 msgstr "содержит"
 
+msgid "doesn't contain"
+msgstr "не содержит"
+
 msgid "equal to"
 msgstr "равно"
 

--- a/sportorg/gui/dialogs/filter_dialog.py
+++ b/sportorg/gui/dialogs/filter_dialog.py
@@ -32,9 +32,14 @@ class DialogFilter(QDialog):
             self.label.setText(headers[i])
             self.label.setObjectName('filter_label_' + str(i))
             self.label.setMaximumWidth(120)
-            self.combo_action = AdvComboBox(
-                self, {translate('contain'), translate('equal to')}, max_width=90
-            )
+            actions = [
+                translate('equal to'),
+                translate('contain'),
+                translate("doesn't contain"),
+            ]
+            default_action = actions[0]
+            self.combo_action = AdvComboBox(self, actions, max_width=90)
+            self.combo_action.setCurrentText(default_action)
             self.combo_action.setObjectName('filter_action_' + str(i))
             self.combo_value = AdvComboBox(self)
             self.combo_value.setMinimumWidth(150)

--- a/tests/test_memory_model.py
+++ b/tests/test_memory_model.py
@@ -1,0 +1,93 @@
+import pytest
+
+from sportorg.gui.tabs.memory_model import AbstractSportOrgMemoryModel
+from sportorg.language import translate
+
+
+@pytest.mark.parametrize(
+    'pattern, value, expected',
+    [
+        ('', '', True),
+        ('', 'Ivan', False),
+        ('Ivan', '', False),
+        ('Ivan', 'Ivan', True),
+        ('Ivan', 'Aleksey', False),
+        ('ivan', 'Ivan', False),
+        ('Ivan', 'Ivanov', False),
+        ('Ivan', 'Ivanov Ivan', False),
+        ('Ivan', 'Ivanov Ivan Ivanovich', False),
+        ('Иван', 'Иван', True),
+        ('1993', '1993', True),
+        ('1993', '4651993', False),
+    ],
+)
+def test_filter_equal_to_action(pattern, value, expected):
+    model = AbstractSportOrgMemoryModel
+    check = model.compile_regex(translate('equal to'), pattern)
+    result = model.match_value(check, str(value))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'pattern, value, expected',
+    [
+        ('', '', True),
+        ('', 'Ivan', True),
+        ('Ivan', '', False),
+        ('Ivan', 'Ivan', True),
+        ('Ivan', 'Aleksey', False),
+        ('ivan', 'Ivan', False),
+        ('Ivan', 'Ivanov', True),
+        ('Ivan', 'Sidorov Ivan', True),
+        ('Ivan', 'Sidorov Ivan Petrovich', True),
+        ('Иван', 'Иван', True),
+        ('1993', '1993', True),
+        ('1993', '4651993', True),
+    ],
+)
+def test_filter_contain_to_action(pattern, value, expected):
+    model = AbstractSportOrgMemoryModel
+    check = model.compile_regex(translate('contain'), pattern)
+    result = model.match_value(check, str(value))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'pattern, value, expected',
+    [
+        ('', '', True),
+        ('', 'Ivan', False),
+        ('Ivan', '', True),
+        ('Ivan', 'Ivan', False),
+        ('Ivan', 'Aleksey', True),
+        ('ivan', 'Ivan', True),
+        ('Ivan', 'Ivanov', False),
+        ('Ivan', 'Sidorov Ivan', False),
+        ('Ivan', 'Sidorov Ivan Petrovich', False),
+        ('Иван', 'Иван', False),
+        ('1993', '1993', False),
+        ('1993', '4651993', False),
+    ],
+)
+def test_filter_doesnt_contain_to_action(pattern, value, expected):
+    model = AbstractSportOrgMemoryModel
+    check = model.compile_regex(translate("doesn't contain"), pattern)
+    result = model.match_value(check, str(value))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'pattern, value, expected',
+    [
+        ('', '', True),
+        ('', 'Ivan', True),
+        ('Ivan', '', True),
+        ('Ivan', 'Ivan', True),
+        ('Ivan', 'Aleksey', True),
+    ],
+)
+def test_filter_wrong_action(pattern, value, expected):
+    model = AbstractSportOrgMemoryModel
+    check = model.compile_regex(translate('wrong action'), pattern)
+    result = model.match_value(check, value)
+    assert result == expected


### PR DESCRIPTION
В фильтр добавлен пункт «не содержит» (по мотивам обсуждения #427). Добавлены тесты.

Регулярное выражение для «не содержит» взято отсюда: https://stackoverflow.com/questions/717644/regular-expression-that-doesnt-contain-certain-string

Вопрос по фильтру. Не лучше вместо регулярных выражений ли использовать `==`, `in`, `not in`?