### PR TITLE
fix: fix bib and card_numbers indexes

### DIFF
--- a/sportorg/gui/dialogs/entry_mass_edit.py
+++ b/sportorg/gui/dialogs/entry_mass_edit.py
@@ -201,7 +201,7 @@ class MassEditDialog(QDialog):
                             cur_person.qual = change_qual
 
                         if self.bib_checkbox.isChecked():
-                            cur_person.change_bib(change_bib)
+                            cur_person.bib = change_bib
 
                         if self.world_code_checkbox.isChecked():
                             cur_person.world_code = change_world_code
@@ -210,7 +210,7 @@ class MassEditDialog(QDialog):
                             cur_person.national_code = change_national_code
 
                         if self.card_checkbox.isChecked():
-                            cur_person.change_card(change_card_number)
+                            cur_person.card_number = change_card_number
 
                         if self.start_time_checkbox.isChecked():
                             cur_person.start_time = change_start_time

--- a/sportorg/gui/dialogs/entry_mass_edit.py
+++ b/sportorg/gui/dialogs/entry_mass_edit.py
@@ -201,7 +201,7 @@ class MassEditDialog(QDialog):
                             cur_person.qual = change_qual
 
                         if self.bib_checkbox.isChecked():
-                            cur_person.bib = change_bib
+                            cur_person.set_bib(change_bib)
 
                         if self.world_code_checkbox.isChecked():
                             cur_person.world_code = change_world_code
@@ -210,7 +210,7 @@ class MassEditDialog(QDialog):
                             cur_person.national_code = change_national_code
 
                         if self.card_checkbox.isChecked():
-                            cur_person.card_number = change_card_number
+                            cur_person.set_card_number(change_card_number)
 
                         if self.start_time_checkbox.isChecked():
                             cur_person.start_time = change_start_time

--- a/sportorg/gui/dialogs/merge_results.py
+++ b/sportorg/gui/dialogs/merge_results.py
@@ -93,9 +93,9 @@ class MergeResultsDialog(QDialog):
 
             result_list.sort(key=lambda c: c.finish_time)
             final_result = ResultSportident()
-            final_result.change_bib(cur_bib)
+            final_result.bib = cur_bib
             final_result.person = result_list[0].person
-            final_result.change_card(result_list[0].card_number)
+            final_result.card_number = result_list[0].card_number
             cur_cp = first_cp
 
             for i in result_list:

--- a/sportorg/gui/dialogs/person_edit.py
+++ b/sportorg/gui/dialogs/person_edit.py
@@ -14,7 +14,14 @@ from sportorg.gui.dialogs.dialog import (
 from sportorg.gui.global_access import GlobalAccess
 from sportorg.language import translate
 from sportorg.models.constant import get_names, get_race_groups, get_race_teams
-from sportorg.models.memory import Limit, Organization, Qualification, find, race
+from sportorg.models.memory import (
+    Limit,
+    Organization,
+    Person,
+    Qualification,
+    find,
+    race,
+)
 from sportorg.models.result.result_calculation import ResultCalculation
 from sportorg.modules.configs.configs import Config
 from sportorg.modules.live.live import live_client
@@ -25,11 +32,13 @@ class PersonEditDialog(BaseDialog):
     GROUP_NAME = ''
     ORGANIZATION_NAME = ''
 
-    def __init__(self, person, is_new=False):
+    def __init__(self, person: Person, is_new=False):
         super().__init__(GlobalAccess().get_main_window())
         self.current_object = person
         self.is_new = is_new
         self.is_item_valid = {}
+        self.bib = person.bib
+        self.card_number = person.card_number
 
         time_format = 'hh:mm:ss'
         if race().get_setting('time_accuracy', 0):
@@ -91,7 +100,7 @@ class PersonEditDialog(BaseDialog):
             ),
             NumberField(
                 title=translate('Bib'),
-                object=person,
+                object=self,
                 key='bib',
                 id='bib',
                 minimum=0,
@@ -123,7 +132,7 @@ class PersonEditDialog(BaseDialog):
             ),
             NumberField(
                 title=translate('Punch card #'),
-                object=person,
+                object=self,
                 key='card_number',
                 id='card_number',
                 minimum=0,
@@ -264,6 +273,10 @@ class PersonEditDialog(BaseDialog):
 
     def apply(self):
         person = self.current_object
+        if self.bib != person.bib:
+            person.set_bib(self.bib)
+        if self.card_number != person.card_number:
+            person.set_card_number(self.card_number)
         if self.is_new:
             race().add_person(person)
 

--- a/sportorg/gui/dialogs/result_edit.py
+++ b/sportorg/gui/dialogs/result_edit.py
@@ -24,7 +24,7 @@ from sportorg.gui.global_access import GlobalAccess
 from sportorg.gui.utils.custom_controls import AdvComboBox, AdvSpinBox, AdvTimeEdit
 from sportorg.language import translate
 from sportorg.models.constant import StatusComments
-from sportorg.models.memory import Limit, ResultStatus, Split, race
+from sportorg.models.memory import Limit, Result, ResultStatus, Split, race
 from sportorg.models.result.result_calculation import ResultCalculation
 from sportorg.models.result.result_checker import ResultChecker, ResultCheckerException
 from sportorg.models.result.split_calculation import GroupSplits
@@ -36,7 +36,7 @@ from sportorg.utils.time import hhmmss_to_time
 class ResultEditDialog(QDialog):
     def __init__(self, result, is_new=False):
         super().__init__(GlobalAccess().get_main_window())
-        self.current_object = result
+        self.current_object: Result = result
         self.is_new = is_new
 
         self.time_format = 'hh:mm:ss'
@@ -260,14 +260,14 @@ class ResultEditDialog(QDialog):
         if new_bib == 0:
             if result.person and result.is_punch():
                 if result.person.card_number == result.card_number:
-                    result.person.change_card(0)
+                    result.person.card_number = 0
             result.person = None
         elif cur_bib != new_bib:
             new_person = race().find_person_by_bib(new_bib)
             if new_person:
                 if result.person:
                     if result.is_punch():
-                        result.person.change_card(0)
+                        result.person.card_number = 0
                 result.person = new_person
                 if result.is_punch():
                     race().person_card_number(result.person, result.card_number)

--- a/sportorg/gui/dialogs/result_edit.py
+++ b/sportorg/gui/dialogs/result_edit.py
@@ -260,14 +260,14 @@ class ResultEditDialog(QDialog):
         if new_bib == 0:
             if result.person and result.is_punch():
                 if result.person.card_number == result.card_number:
-                    result.person.card_number = 0
+                    result.person.set_card_number(0)
             result.person = None
         elif cur_bib != new_bib:
             new_person = race().find_person_by_bib(new_bib)
             if new_person:
                 if result.person:
                     if result.is_punch():
-                        result.person.card_number = 0
+                        result.person.pset_card_number(0)
                 result.person = new_person
                 if result.is_punch():
                     race().person_card_number(result.person, result.card_number)

--- a/sportorg/gui/dialogs/settings.py
+++ b/sportorg/gui/dialogs/settings.py
@@ -24,6 +24,7 @@ from sportorg.models.memory import (
     get_current_race_index,
     move_down_race,
     move_up_race,
+    race,
     races,
     set_current_race_index,
 )

--- a/sportorg/gui/dialogs/text_io.py
+++ b/sportorg/gui/dialogs/text_io.py
@@ -384,7 +384,7 @@ def set_property(person, key, value, **options):
     elif key == translate('Bib'):
         if value.isdigit():
             new_bib = int(value)
-            person.change_bib(new_bib)
+            person.bib = new_bib
     elif key == translate('Comment'):
         person.comment = value
     elif key == translate('IOF id'):

--- a/sportorg/gui/dialogs/text_io.py
+++ b/sportorg/gui/dialogs/text_io.py
@@ -384,7 +384,7 @@ def set_property(person, key, value, **options):
     elif key == translate('Bib'):
         if value.isdigit():
             new_bib = int(value)
-            person.bib = new_bib
+            person.set_bib(new_bib)
     elif key == translate('Comment'):
         person.comment = value
     elif key == translate('IOF id'):

--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -619,6 +619,7 @@ class RecheckingAction(Action, metaclass=ActionFactory):
     def execute(self):
         ResultChecker.check_all()
         ResultCalculation(race()).process_results()
+        race().rebuild_indexes()
         self.app.refresh()
 
 

--- a/sportorg/gui/tabs/memory_model.py
+++ b/sportorg/gui/tabs/memory_model.py
@@ -279,8 +279,8 @@ class PersonMemoryModel(AbstractSportOrgMemoryModel):
         person = self.race.persons[position]
         new_person = copy(person)
         new_person.id = uuid.uuid4()
-        new_person.bib = 0
-        new_person.card_number = 0
+        new_person.set_bib(0)
+        new_person.set_card_number(0)
         self.race.persons.insert(position, new_person)
 
     def get_values_from_object(self, obj):

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -1415,7 +1415,10 @@ class Person(Model):
             other_person = r.person_index_bib[new_bib]
             if not other_person is self:
                 logging.info(
-                    f'Duplicate bib {new_bib} (do nothing): {self} | {other_person}'
+                    'Duplicate bib %s (do nothing): %s | %s',
+                    new_bib,
+                    self,
+                    other_person,
                 )
         r.person_index_bib[new_bib] = self
 
@@ -1445,7 +1448,10 @@ class Person(Model):
             other_person = r.person_index_card[new_card]
             if not other_person is self:
                 logging.info(
-                    f'Duplicate card {new_card} (do nothing): {self} | {other_person}'
+                    'Duplicate card %s (do nothing): %s | %s',
+                    new_card,
+                    self,
+                    other_person,
                 )
         r.person_index_card[new_card] = self
 

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -1372,8 +1372,8 @@ class Person(Model):
     def update_data(self, data):
         self.name = str(data['name'])
         self.surname = str(data['surname'])
-        self.card_number = int(data['card_number'])
-        self.bib = int(data['bib'])
+        self.set_card_number(int(data['card_number']))
+        self.set_bib(int(data['bib']))
         self.contact = []
         if data['world_code']:
             self.world_code = str(data['world_code'])
@@ -1399,9 +1399,11 @@ class Person(Model):
 
     @bib.setter
     def bib(self, new_bib: int):
+        raise NotImplementedError('Please, use set_bib()')
+
+    def set_bib(self, new_bib: int) -> None:
         if self._bib == new_bib:
             return
-
         self._index_bib(new_bib)
         self._bib = new_bib
 
@@ -1426,6 +1428,9 @@ class Person(Model):
 
     @card_number.setter
     def card_number(self, new_card: int):
+        raise NotImplementedError('Please, use set_card_number()')
+
+    def set_card_number(self, new_card: int):
         if self._card_number == new_card:
             return
 
@@ -1749,10 +1754,10 @@ class Race(Model):
         return self.data.get_days(date_)
 
     def person_card_number(self, person: Person, number=0):
-        person.card_number = number
+        person.set_card_number(number)
         for p in self.persons:
             if p.card_number == number and p != person:
-                p.card_number = 0
+                p.set_card_number(0)
                 p.is_rented_card = False
                 return p
 
@@ -2351,7 +2356,7 @@ class RelayLeg:
 
     def set_bib(self):
         if self.person:
-            self.person.bib = self.get_bib()
+            self.person.set_bib(self.get_bib())
 
     def set_person(self, person):
         self.person = person

--- a/sportorg/models/start/relay.py
+++ b/sportorg/models/start/relay.py
@@ -48,7 +48,7 @@ def get_leg_count():
 
 
 def set_next_relay_number_to_person(person):
-    person.bib = get_next_relay_number_setting()
+    person.set_bib(get_next_relay_number_setting())
     set_next_relay_number(get_next_relay_number(person.bib))
 
 

--- a/sportorg/models/start/relay.py
+++ b/sportorg/models/start/relay.py
@@ -48,7 +48,7 @@ def get_leg_count():
 
 
 def set_next_relay_number_to_person(person):
-    person.change_bib(get_next_relay_number_setting())
+    person.bib = get_next_relay_number_setting()
     set_next_relay_number(get_next_relay_number(person.bib))
 
 

--- a/sportorg/models/start/start_preparation.py
+++ b/sportorg/models/start/start_preparation.py
@@ -573,10 +573,10 @@ class StartNumberManager:
                 if current_person.start_time:
                     start_time = current_person.start_time
                     delta = (start_time - first_start).to_minute()
-                    current_person.bib = int(min_num + delta)
+                    current_person.set_bib(int(min_num + delta))
                     max_assigned_num = max(max_assigned_num, current_person.bib)
                 else:
-                    current_person.bib = 0
+                    current_person.set_bib(0)
 
         if max_assigned_num > first_number:
             return max_assigned_num + 1
@@ -586,7 +586,7 @@ class StartNumberManager:
         cur_number = first_number
         if persons and len(persons) > 0:
             for current_person in persons:
-                current_person.bib = cur_number
+                current_person.set_bib(cur_number)
                 cur_number += interval
         return cur_number
 
@@ -821,14 +821,14 @@ def copy_bib_to_card_number():
     obj = race()
     for person in obj.persons:
         if person.bib:
-            person.card_number = person.bib
+            person.set_card_number(person.bib)
 
 
 def copy_card_number_to_bib():
     obj = race()
     for person in obj.persons:
         if person.card_number:
-            person.bib = person.card_number
+            person.set_bib(person.card_number)
 
 
 def clone_relay_legs(min_bib, max_bib, increment):
@@ -841,6 +841,6 @@ def clone_relay_legs(min_bib, max_bib, increment):
         if person.bib and min_bib <= person.bib <= max_bib:
             new_person = copy(person)
             new_person.id = uuid.uuid4()
-            new_person.bib = person.bib + increment
-            new_person.card_number = 0
+            new_person.set_bib(person.bib + increment)
+            new_person.set_card_number(0)
             obj.persons.append(new_person)

--- a/sportorg/models/start/start_preparation.py
+++ b/sportorg/models/start/start_preparation.py
@@ -573,10 +573,10 @@ class StartNumberManager:
                 if current_person.start_time:
                     start_time = current_person.start_time
                     delta = (start_time - first_start).to_minute()
-                    current_person.change_bib(int(min_num + delta))
+                    current_person.bib = int(min_num + delta)
                     max_assigned_num = max(max_assigned_num, current_person.bib)
                 else:
-                    current_person.change_bib(0)
+                    current_person.bib = 0
 
         if max_assigned_num > first_number:
             return max_assigned_num + 1
@@ -586,7 +586,7 @@ class StartNumberManager:
         cur_number = first_number
         if persons and len(persons) > 0:
             for current_person in persons:
-                current_person.change_bib(cur_number)
+                current_person.bib = cur_number
                 cur_number += interval
         return cur_number
 
@@ -821,14 +821,14 @@ def copy_bib_to_card_number():
     obj = race()
     for person in obj.persons:
         if person.bib:
-            person.change_card(person.bib)
+            person.card_number = person.bib
 
 
 def copy_card_number_to_bib():
     obj = race()
     for person in obj.persons:
         if person.card_number:
-            person.change_bib(person.card_number)
+            person.bib = person.card_number
 
 
 def clone_relay_legs(min_bib, max_bib, increment):
@@ -841,6 +841,6 @@ def clone_relay_legs(min_bib, max_bib, increment):
         if person.bib and min_bib <= person.bib <= max_bib:
             new_person = copy(person)
             new_person.id = uuid.uuid4()
-            new_person.change_bib(person.bib + increment)
+            new_person.bib = person.bib + increment
             new_person.card_number = 0
             obj.persons.append(new_person)

--- a/sportorg/modules/backup/json.py
+++ b/sportorg/modules/backup/json.py
@@ -43,6 +43,8 @@ def load(file):
     # while parsing of data index is created in old object, available as race()
     obj.person_index_card = tmp_obj.person_index_card
     obj.person_index_bib = tmp_obj.person_index_bib
+    tmp_obj.person_index_card = {}
+    tmp_obj.person_index_bib = {}
 
     ResultChecker.check_all()
     ResultCalculation(obj).process_results()

--- a/sportorg/modules/backup/json.py
+++ b/sportorg/modules/backup/json.py
@@ -40,12 +40,6 @@ def load(file):
     set_current_race_index(current_race)
     obj = race()
 
-    # while parsing of data index is created in old object, available as race()
-    obj.person_index_card = tmp_obj.person_index_card
-    obj.person_index_bib = tmp_obj.person_index_bib
-    tmp_obj.person_index_card = {}
-    tmp_obj.person_index_bib = {}
-
     ResultChecker.check_all()
     ResultCalculation(obj).process_results()
     RaceSplits(obj).generate()
@@ -68,11 +62,20 @@ def get_races_from_file(file):
         obj = Race()
         obj.id = uuid.UUID(str(race_dict['id']))
         obj.update_data(race_dict)
+        # while parsing of data index is created in old object, available as race()
+        move_indexes_to_new_race(obj)
         event.append(obj)
     current_race = 0
     if 'current_race' in data:
         current_race = int(data['current_race'])
     return event, current_race
+
+
+def move_indexes_to_new_race(obj):
+    obj.person_index_bib = race().person_index_bib
+    race().person_index_bib = {}
+    obj.person_index_card = race().person_index_card
+    race().person_index_card = {}
 
 
 def race_migrate(data):

--- a/sportorg/modules/iof/iof_xml.py
+++ b/sportorg/modules/iof/iof_xml.py
@@ -156,14 +156,14 @@ def create_person(person_entry):
     if 'race_numbers' in person_entry and len(person_entry['race_numbers']):
         person.comment = 'C:' + ''.join(person_entry['race_numbers'])
     if 'control_card' in person_entry and person_entry['control_card']:
-        person.change_card(int(person_entry['control_card']))
+        person.card_number = int(person_entry['control_card'])
     if 'bib' in person_entry['person'] and person_entry['person']['bib']:
-        person.change_bib(int(person_entry['person']['bib']))
+        person.bib = int(person_entry['person']['bib'])
     elif (
         'bib' in person_entry['person']['extensions']
         and person_entry['person']['extensions']['bib']
     ):
-        person.change_bib(int(person_entry['person']['extensions']['bib']))
+        person.bib = int(person_entry['person']['extensions']['bib'])
     if (
         'qual' in person_entry['person']['extensions']
         and person_entry['person']['extensions']['qual']
@@ -260,9 +260,9 @@ def import_from_result_list(results) -> None:
         if card > 0:
             new_result.card_number = card
         if person.card_number == 0:
-            person.change_card(new_result.card_number)
+            person.card_number = new_result.card_number
 
-        person.change_bib(int(bib))
+        person.bib = int(bib)
         person.start_time = start
         new_result.person = person
 

--- a/sportorg/modules/iof/iof_xml.py
+++ b/sportorg/modules/iof/iof_xml.py
@@ -156,14 +156,14 @@ def create_person(person_entry):
     if 'race_numbers' in person_entry and len(person_entry['race_numbers']):
         person.comment = 'C:' + ''.join(person_entry['race_numbers'])
     if 'control_card' in person_entry and person_entry['control_card']:
-        person.card_number = int(person_entry['control_card'])
+        person.set_card_number(int(person_entry['control_card']))
     if 'bib' in person_entry['person'] and person_entry['person']['bib']:
-        person.bib = int(person_entry['person']['bib'])
+        person.set_bib(int(person_entry['person']['bib']))
     elif (
         'bib' in person_entry['person']['extensions']
         and person_entry['person']['extensions']['bib']
     ):
-        person.bib = int(person_entry['person']['extensions']['bib'])
+        person.set_bib(int(person_entry['person']['extensions']['bib']))
     if (
         'qual' in person_entry['person']['extensions']
         and person_entry['person']['extensions']['qual']
@@ -199,11 +199,10 @@ def import_from_entry_list(entries) -> None:
                     person.card_number,
                 )
             )
-            person.card_number = 0
+            person.set_card_number(0)
     if len(persons_dupl_names):
         logging.info('{}'.format(translate('Duplicate names')))
         for person in sorted(persons_dupl_names, key=lambda x: x.full_name):
-            person.card_number = 0
             logging.info(
                 '{} {} {} {}'.format(
                     person.full_name,
@@ -260,9 +259,9 @@ def import_from_result_list(results) -> None:
         if card > 0:
             new_result.card_number = card
         if person.card_number == 0:
-            person.card_number = new_result.card_number
+            person.set_card_number(new_result.card_number)
 
-        person.bib = int(bib)
+        person.set_bib(int(bib))
         person.start_time = start
         new_result.person = person
 

--- a/sportorg/modules/recovery/recovery_orgeo_finish_csv.py
+++ b/sportorg/modules/recovery/recovery_orgeo_finish_csv.py
@@ -62,7 +62,7 @@ def recovery(file_name: str, race: Race) -> None:
                 person.name = name[spl_pos + 1 :]
             else:
                 person.name = name
-            person.change_bib(int(bib))
+            person.bib = int(bib)
 
             team_name = tokens[POS_TEAM]
             team = race.find_team(team_name)

--- a/sportorg/modules/recovery/recovery_orgeo_finish_csv.py
+++ b/sportorg/modules/recovery/recovery_orgeo_finish_csv.py
@@ -62,7 +62,7 @@ def recovery(file_name: str, race: Race) -> None:
                 person.name = name[spl_pos + 1 :]
             else:
                 person.name = name
-            person.bib = int(bib)
+            person.set_bib(int(bib))
 
             team_name = tokens[POS_TEAM]
             team = race.find_team(team_name)

--- a/sportorg/modules/sportident/result_generation.py
+++ b/sportorg/modules/sportident/result_generation.py
@@ -218,12 +218,12 @@ class ResultSportidentGeneration:
 
     def _create_person(self):
         new_person = Person()
-        new_person.change_bib(self._get_max_bib() + 1)
+        new_person.bib = self._get_max_bib() + 1
         existing_person = race().find_person_by_card(self._result.card_number)
         if existing_person:
             new_person_copy = deepcopy(existing_person)
             new_person_copy.id = new_person.id
-            new_person_copy.change_bib(new_person.bib)
+            new_person_copy.bib = new_person.bib
             new_person = new_person_copy
             new_person.card_number = 0
         else:

--- a/sportorg/modules/sportident/result_generation.py
+++ b/sportorg/modules/sportident/result_generation.py
@@ -218,14 +218,14 @@ class ResultSportidentGeneration:
 
     def _create_person(self):
         new_person = Person()
-        new_person.bib = self._get_max_bib() + 1
+        new_person.set_bib(self._get_max_bib() + 1)
         existing_person = race().find_person_by_card(self._result.card_number)
         if existing_person:
             new_person_copy = deepcopy(existing_person)
             new_person_copy.id = new_person.id
-            new_person_copy.bib = new_person.bib
+            new_person_copy.set_bib(new_person.bib)
             new_person = new_person_copy
-            new_person.card_number = 0
+            new_person.set_card_number(0)
         else:
             new_person.surname = translate('Competitor') + ' #' + str(new_person.bib)
 

--- a/sportorg/modules/winorient/wdb.py
+++ b/sportorg/modules/winorient/wdb.py
@@ -120,7 +120,7 @@ class WinOrientBinary:
             index_of_first_space = str(man.name.strip()).find(' ')
             if index_of_first_space > 0:
                 new_person.name = man.name.strip()[index_of_first_space + 1 :].strip()
-            new_person.change_bib(man.number)
+            new_person.bib = man.number
             if man.qualification:
                 if man.qualification == 10:
                     man.qualification = Qualification.MSMK.value  # Convert ZMS to MSMK

--- a/sportorg/modules/winorient/wdb.py
+++ b/sportorg/modules/winorient/wdb.py
@@ -120,7 +120,7 @@ class WinOrientBinary:
             index_of_first_space = str(man.name.strip()).find(' ')
             if index_of_first_space > 0:
                 new_person.name = man.name.strip()[index_of_first_space + 1 :].strip()
-            new_person.bib = man.number
+            new_person.set_bib(man.number)
             if man.qualification:
                 if man.qualification == 10:
                     man.qualification = Qualification.MSMK.value  # Convert ZMS to MSMK

--- a/sportorg/modules/winorient/winorient.py
+++ b/sportorg/modules/winorient/winorient.py
@@ -39,9 +39,9 @@ def import_csv(source):
         person = memory.Person()
         person.name = person_dict['name']
         person.surname = person_dict['surname']
-        person.bib = int(person_dict['bib'])
+        person.set_bib(int(person_dict['bib']))
         person.set_year(person_dict['year'])
-        person.card_number = int(person_dict['sportident_card'])
+        person.set_card_number(int(person_dict['sportident_card']))
         person.group = memory.find(obj.groups, name=person_dict['group_name'])
         person.organization = person_org
         person.qual = Qualification(qual_id)
@@ -73,7 +73,7 @@ def import_csv(source):
                     person.card_number,
                 )
             )
-            person.card_number = 0
+            person.set_card_number(0)
     if len(persons_dupl_names):
         logging.info('{}'.format(translate('Duplicate names')))
         for person in sorted(persons_dupl_names, key=lambda x: x.full_name):

--- a/sportorg/modules/winorient/winorient.py
+++ b/sportorg/modules/winorient/winorient.py
@@ -39,9 +39,9 @@ def import_csv(source):
         person = memory.Person()
         person.name = person_dict['name']
         person.surname = person_dict['surname']
-        person.change_bib(person_dict['bib'])
+        person.bib = int(person_dict['bib'])
         person.set_year(person_dict['year'])
-        person.change_card(int(person_dict['sportident_card']))
+        person.card_number = int(person_dict['sportident_card'])
         person.group = memory.find(obj.groups, name=person_dict['group_name'])
         person.organization = person_org
         person.qual = Qualification(qual_id)


### PR DESCRIPTION
Починил (надеюсь) индекс номеров участников и чипов. 

Доступ к номеру участника и чипу сделал через getter/setter и убрал change_bib() — для исключения случайного присваивания без изменения индекса.

Обновление индекса при удалении спортсменов.

Обнаружил, что при открытии базы с несколькими днями, пересчёт результатов/сплитов происходит только для текущего дня, для остальных дней пересчёта не происходит. Сделал, чтобы индексы создавались для всех дней. Не возникнет ли проблема с проверкой отметки — не знаю.

В некоторых случаях возможны одинаковые номера и одинаковые чипы (жеребьёвка, массовое редактирование). Добавил сообщение в логи.

Дублирующиеся номера/чипы — потенциально неприятный момент. Если создали участника с дублирующимся чипом, а затем удалили его — этот чип пропадёт из индекса. И первого при считывании исходный участник автоматически не определится (наверное). 