### PR TITLE
Correct ardf label and send online all controls (option)

### DIFF
--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -640,7 +640,7 @@ msgid "by scores"
 msgstr "по баллам"
 
 msgid "ardf"
-msgstr "ADRF"
+msgstr "ARDF"
 
 msgid "rogain scores"
 msgstr "рогейн (45КП = 4балла, 78КП = 7баллов)"

--- a/languages/ru_RU/LC_MESSAGES/sportorg.po
+++ b/languages/ru_RU/LC_MESSAGES/sportorg.po
@@ -1521,6 +1521,9 @@ msgstr "Первый КП"
 msgid "CP increment"
 msgstr "Инкремент КП"
 
+msgid "Sending the entire contents of the chip"
+msgstr "Отправка всего содержимого чипа"
+
 msgid "Online results sending"
 msgstr "Отправка онлайн результатов"
 

--- a/sportorg/gui/dialogs/live_dialog.py
+++ b/sportorg/gui/dialogs/live_dialog.py
@@ -58,6 +58,10 @@ class LiveDialog(QDialog):
         self.item_live_enabled = QCheckBox(translate('Enabled'))
         self.layout.addRow(self.item_live_enabled)
 
+        self.item_sending_all_controls = QCheckBox(translate('Sending the entire contents of the chip'))
+        self.item_sending_all_controls.setChecked(True)
+        self.layout.addRow(self.item_sending_all_controls)
+
         self.item_result_sending = QCheckBox(translate('Online results sending'))
         self.item_result_sending.setChecked(True)
         self.layout.addRow(self.item_result_sending)
@@ -128,6 +132,7 @@ class LiveDialog(QDialog):
 
     def on_enable_checkbox_state_changed(self):
         state = self.item_live_enabled.isChecked()
+        self.item_sending_all_controls.setEnabled(state)
         self.item_result_sending.setEnabled(state)
         self.item_cp_sending.setEnabled(state)
         self.online_cp_box.setEnabled(state)
@@ -151,6 +156,7 @@ class LiveDialog(QDialog):
             urls = [url]
         live_enabled = obj.get_setting('live_enabled', False)
 
+        live_sending_all_controls = obj.get_setting('live_sending_all_controls', False)
         live_results_enabled = obj.get_setting('live_results_enabled', True)
         live_cp_enabled = obj.get_setting('live_cp_enabled', False)
         live_cp_code = obj.get_setting('live_cp_code', '10')
@@ -160,6 +166,7 @@ class LiveDialog(QDialog):
 
         self.item_url.setText(encode_urls(urls))
         self.item_live_enabled.setChecked(live_enabled)
+        self.item_sending_all_controls.setChecked(live_sending_all_controls)
         self.item_result_sending.setChecked(live_results_enabled)
         self.item_cp_sending.setChecked(live_cp_enabled)
         self.online_cp_from_finish_code.setValue(int(live_cp_code))
@@ -173,6 +180,7 @@ class LiveDialog(QDialog):
         obj = race()
         obj.set_setting('live_urls', decode_urls(self.item_url.text()))
         obj.set_setting('live_enabled', self.item_live_enabled.isChecked())
+        obj.set_setting('live_sending_all_controls', self.item_sending_all_controls.isChecked())
         obj.set_setting('live_results_enabled', self.item_result_sending.isChecked())
         obj.set_setting('live_cp_enabled', self.item_cp_sending.isChecked())
         obj.set_setting(

--- a/sportorg/gui/dialogs/live_dialog.py
+++ b/sportorg/gui/dialogs/live_dialog.py
@@ -58,7 +58,9 @@ class LiveDialog(QDialog):
         self.item_live_enabled = QCheckBox(translate('Enabled'))
         self.layout.addRow(self.item_live_enabled)
 
-        self.item_sending_all_controls = QCheckBox(translate('Sending the entire contents of the chip'))
+        self.item_sending_all_controls = QCheckBox(
+            translate('Sending the entire contents of the chip')
+        )
         self.item_sending_all_controls.setChecked(True)
         self.layout.addRow(self.item_sending_all_controls)
 
@@ -180,7 +182,9 @@ class LiveDialog(QDialog):
         obj = race()
         obj.set_setting('live_urls', decode_urls(self.item_url.text()))
         obj.set_setting('live_enabled', self.item_live_enabled.isChecked())
-        obj.set_setting('live_sending_all_controls', self.item_sending_all_controls.isChecked())
+        obj.set_setting(
+            'live_sending_all_controls', self.item_sending_all_controls.isChecked()
+        )
         obj.set_setting('live_results_enabled', self.item_result_sending.isChecked())
         obj.set_setting('live_cp_enabled', self.item_cp_sending.isChecked())
         obj.set_setting(

--- a/sportorg/gui/dialogs/settings.py
+++ b/sportorg/gui/dialogs/settings.py
@@ -24,7 +24,6 @@ from sportorg.models.memory import (
     get_current_race_index,
     move_down_race,
     move_up_race,
-    race,
     races,
     set_current_race_index,
 )

--- a/sportorg/modules/live/orgeo.py
+++ b/sportorg/modules/live/orgeo.py
@@ -135,7 +135,7 @@ def _get_person_obj(data, race_data, result=None):
             obj['splits'] = []
             splits = []
             for split in result['splits']:
-                if split['is_correct']:
+                if split['is_correct'] or race_data['settings']['live_sending_all_controls'] == True:
                     splits.append(split)
             for i in range(len(splits)):
                 # fmt: off

--- a/sportorg/modules/live/orgeo.py
+++ b/sportorg/modules/live/orgeo.py
@@ -135,7 +135,10 @@ def _get_person_obj(data, race_data, result=None):
             obj['splits'] = []
             splits = []
             for split in result['splits']:
-                if split['is_correct'] or race_data['settings']['live_sending_all_controls'] == True:
+                if (
+                    split['is_correct']
+                    or race_data['settings']['live_sending_all_controls'] == True
+                ):
                     splits.append(split)
             for i in range(len(splits)):
                 # fmt: off


### PR DESCRIPTION
= Подкорректирована опечатка в label для режима проверки отметки ARDF
+ Добавлена новая опция в настройках Live с возможностью отправлять все содержимое чипа, т.к. не всегда в онлайне нужно выводить только то что пройдено по самой дистанции.