### PR TITLE
fix: rebuild indexes after major changing/deleting bibs and cards operations

### DIFF
--- a/sportorg/gui/main_window.py
+++ b/sportorg/gui/main_window.py
@@ -857,6 +857,7 @@ class MainWindow(QMainWindow):
             res = race().delete_persons(indexes)
             ResultCalculation(race()).process_results()
             live_client.delete(res)
+            race().rebuild_indexes()
         elif tab == 1:
             res = race().delete_results(indexes)
             ResultCalculation(race()).process_results()

--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -412,6 +412,7 @@ class DeleteAction(Action, metaclass=ActionFactory):
 class TextExchangeAction(Action, metaclass=ActionFactory):
     def execute(self):
         TextExchangeDialog().exec_()
+        race().rebuild_indexes()
         self.app.refresh()
 
 
@@ -419,6 +420,7 @@ class MassEditAction(Action, metaclass=ActionFactory):
     def execute(self):
         if self.app.current_tab == 0:
             MassEditDialog().exec_()
+            race().rebuild_indexes()
             self.app.refresh()
 
         if self.app.current_tab == 2:

--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -1419,7 +1419,7 @@ class Person(Model):
             other_person = r.person_index_bib[new_bib]
             if not other_person is self:
                 logging.info(
-                    'Duplicate bib %s (do nothing): %s | %s',
+                    'Duplicate bib %s: %s (indexed) | %s (not indexed)',
                     new_bib,
                     self,
                     other_person,
@@ -1452,7 +1452,7 @@ class Person(Model):
             other_person = r.person_index_card[new_card]
             if not other_person is self:
                 logging.info(
-                    'Duplicate card %s (do nothing): %s | %s',
+                    'Duplicate card %s: %s (indexed) | %s (not indexed)',
                     new_card,
                     self,
                     other_person,


### PR DESCRIPTION
В базе могут содержаться дублирующиеся номера и чипы. Если из двух дублирующихся удалить индексированного участника, второй остаётся не индексированным. И не находится, например, при считывании чипа. При этом секретарь точно знает, что участник с таким номером или чипом точно есть в базе. Стрессовая ситуация, секретарь может не придумать, что делать.

Делаю перестройку индекса после основных операций, при которых возможно удаление индекса.

Также в логах отражается, какой из двух участников с дублирующимимя номерами / чипами проиндексирован, а какой нет.

Выявленный побочный эффект. Если есть участники с дублирующимися номерами / чипами, они могут быть проиндексированы по-разному в зависимости от сортировки вкладки Участники. Правильнее, если бы индексация сохранялась.

Повторяющиеся сообщения в логах в процессе обработки одной операции. Например, при массовом редактировании: одно сообщение о дублирующихся чипах при присвоении дублирующегося чипа, второе такое же сообщение при перестройке индекса.

