### PR TITLE
fix: send results online in correct order (not reversed)

### DIFF
--- a/sportorg/gui/menu/actions.py
+++ b/sportorg/gui/menu/actions.py
@@ -844,6 +844,9 @@ class OnlineSendAction(Action, metaclass=ActionFactory):
                 if index >= len(items):
                     pass
                 selected_items.append(items[index])
+            if self.app.current_tab == 1:
+                # Most recent results are sent last
+                selected_items = selected_items[::-1]
             live_client.send(selected_items)
         except Exception as e:
             logging.exception(e)


### PR DESCRIPTION
Работа с онлайн, задача: обновить все (или часть) результатов. 

Действие: Выделить все результаты (Ctrl+A), отправить онлайн (Ctrl+K).

Ранее: результаты отправлялись «сверху» «вниз»: сначала самые свежие результаты, затем самые старые. В блоке «последних результатах» на orgeo появлялись результаты первых финишировавших. Если секретарь хочет, чтобы отправка результатов не влияла на блок «последние результаты», надо или сортировать результаты перед отправкой, или после отправки по одному отправлять шесть последних результатов.

Сейчас: «верхние» (последние) результаты отправляются последними, в блоке «последние результаты» содержатся шесть последних финишей.