### PR TITLE
perf: acceleration of searching for COM ports in the windows system

### DIFF
--- a/sportorg/modules/sportident/sireader.py
+++ b/sportorg/modules/sportident/sireader.py
@@ -28,7 +28,7 @@ from sportorg.language import translate
 from sportorg.models import memory
 from sportorg.modules.sportident import backup
 from sportorg.utils.time import time_to_otime
-
+from serial.tools import list_ports
 
 class SIReaderCommand:
     def __init__(self, command, data=None):
@@ -264,26 +264,7 @@ class SIReaderClient:
 
     @staticmethod
     def get_ports():
-        ports = []
-        scan_ports = []
-        if platform.system() == "Linux":
-            scan_ports = [
-                os.path.join("/dev", f)
-                for f in os.listdir("/dev")
-                if re.match("ttyS.*|ttyUSB.*", f)
-            ]
-        elif platform.system() == "Windows":
-            scan_ports = ["COM" + str(i) for i in range(48)]
-
-        for p in scan_ports:
-            try:
-                com = serial.Serial(p, 38400, timeout=5)
-                com.close()
-                ports.append(p)
-            except serial.SerialException:
-                continue
-
-        return ports
+        return [port.device for port in list_ports.comports()]
 
     def choose_port(self):
         si_port = memory.race().get_setting("system_port", "")


### PR DESCRIPTION
<!-- Please explain the changes you made -->
On MacOs and Linux searching serial devices so fast, but on windows very very slow - this commit fixed it
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/sportorg/pysport/blob/master/CONTRIBUTING.md
- you have checked that all tests pass
- you have updated the changelog (if needed):
  https://github.com/sportorg/pysport/blob/master/changelog.md
  https://github.com/sportorg/pysport/blob/master/changelog_ru.md
-->
