### PR TITLE
fix: the template combo box was too small to fit the template name

### DIFF
--- a/sportorg/gui/dialogs/print_properties.py
+++ b/sportorg/gui/dialogs/print_properties.py
@@ -71,7 +71,7 @@ class PrintPropertiesDialog(QDialog):
 
         self.label_template = QLabel(translate("Template"))
         self.item_template = AdvComboBox()
-        self.item_template.setMaximumWidth(200)
+        self.item_template.setMaximumWidth(350)
         self.item_template.addItem(translate("Internal printing"))
         self.item_template.addItem(
             translate("Internal printing") + " " + translate("scale") + "=75"


### PR DESCRIPTION
Увеличен минимальный размер выпадающего списка для выбора шаблона в окне настроек печати. Теперь большинство названий шаблонов влезают полностью.
