### PR TITLE
fix: fix AdvComboBox behaviour

### DIFF
--- a/sportorg/gui/dialogs/print_properties.py
+++ b/sportorg/gui/dialogs/print_properties.py
@@ -70,8 +70,7 @@ class PrintPropertiesDialog(QDialog):
         self.layout.addRow(self.selected_split_printer)
 
         self.label_template = QLabel(translate("Template"))
-        self.item_template = AdvComboBox()
-        self.item_template.setMaximumWidth(350)
+        self.item_template = AdvComboBox(min_width=160, min_context_length_symbols=32)
         self.item_template.addItem(translate("Internal printing"))
         self.item_template.addItem(
             translate("Internal printing") + " " + translate("scale") + "=75"

--- a/sportorg/gui/dialogs/report_dialog.py
+++ b/sportorg/gui/dialogs/report_dialog.py
@@ -65,7 +65,7 @@ class ReportDialog(QDialog):
         self.layout = QFormLayout(self)
 
         self.label_template = QLabel(translate("Template"))
-        self.item_template = AdvComboBox()
+        self.item_template = AdvComboBox(min_width=250, min_context_length_symbols=60)
         self.item_template.addItems(
             sorted(get_templates(settings.template_dir("reports")))
         )

--- a/sportorg/gui/utils/custom_controls.py
+++ b/sportorg/gui/utils/custom_controls.py
@@ -30,7 +30,14 @@ class AdvComboBox(QComboBox):
     Found in Internet by Sergei
     """
 
-    def __init__(self, parent=None, val_list=None, max_width=0):
+    def __init__(
+        self,
+        parent=None,
+        val_list=None,
+        max_width=0,
+        min_width=0,
+        min_context_length_symbols=0,
+    ):
         super(AdvComboBox, self).__init__(parent)
 
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
@@ -61,6 +68,15 @@ class AdvComboBox(QComboBox):
 
         if max_width > 0:
             self.setMaximumWidth(max_width)
+
+        if min_width > 0:
+            self.setMinimumWidth(min_width)
+
+        if min_context_length_symbols > 0:
+            self.setMinimumContentsLength(min_context_length_symbols)
+            self.setSizeAdjustPolicy(
+                self.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+            )
 
     def wheelEvent(self, ev):
         if ev.type() == QtCore.QEvent.Wheel:


### PR DESCRIPTION
Исправлено поведение поля выбора шаблонов для печати сплитов и протоколов

Ранее у диалоговых окон печати протоколов и настроек печати при открытии устанавливался размер, соответствующий самому длинному названию шаблона. Если в папке лежал шаблон с длинным именем, диалоговые окна становились непропорционально широкими, их ширину нельзя было уменьшить. Ранее было черновое исправление такого поведения (#499)

Теперь можно задавать минимальную (в пикселях) и рекомендуемую (в символах) ширину поля выбора. Значения 160, 32 и 250, 60 подобраны для лучшего выбора наиболее популярных шаблонов