### PR TITLE
fix: use current-day time for MULTI_DAY_RACE overtime check

### DIFF
--- a/sportorg/models/memory.py
+++ b/sportorg/models/memory.py
@@ -781,10 +781,14 @@ class Result(ABC):
         ret = self.get_result_otime()
         return self.status, ret.to_msec()
 
-    def get_result_otime(self):
-        race_type = RaceType.INDIVIDUAL_RACE
+    def get_race_type(self, fallback: RaceType = RaceType.INDIVIDUAL_RACE) -> RaceType:
+        race_type = fallback
         if self.person and self.person.group:
             race_type = self.person.group.race_type
+        return race_type
+
+    def get_result_otime(self):
+        race_type = self.get_race_type()
 
         if race_type == RaceType.INDIVIDUAL_RACE:
             return self.get_result_otime_current_day()
@@ -2338,13 +2342,7 @@ class Qualification(IntEnum):
         }
 
         def normalize_qual(raw_name: str) -> str:
-            return (
-                str(raw_name)
-                .strip()
-                .casefold()
-                .replace(" ", "")
-                .replace(".", "")
-            )
+            return str(raw_name).strip().casefold().replace(" ", "").replace(".", "")
 
         aliases = {}
         for title, code in qual_reverse.items():

--- a/sportorg/models/result/result_checker.py
+++ b/sportorg/models/result/result_checker.py
@@ -1,14 +1,15 @@
 from sportorg.common.otime import OTime
 from sportorg.models.constant import StatusComments
 from sportorg.models.memory import (
+    CourseControl,
     Person,
+    RaceType,
     Result,
     ResultSportident,
     ResultStatus,
+    Split,
     find,
     race,
-    Split,
-    CourseControl,
 )
 
 
@@ -62,7 +63,7 @@ class ResultChecker:
         return result.check(course)
 
     @classmethod
-    def checking(cls, result):
+    def checking(cls, result: Result):
         if result.person is None:
             raise ResultCheckerException("Not person")
         o = cls(result.person)
@@ -85,23 +86,7 @@ class ResultChecker:
                 result.status = ResultStatus.MISS_PENALTY_LAP
 
             elif result.person.group and result.person.group.max_time.to_msec():
-                rp_mode = race().get_setting("result_processing_mode", "time")
-                result_time = result.get_result_otime()
-                max_time = result.person.group.max_time
-                if rp_mode in ("time", "ardf"):
-                    if result_time > max_time:
-                        result.status = ResultStatus.OVERTIME
-                elif rp_mode == "scores":
-                    max_overrun_time = OTime(
-                        msec=race().get_setting(
-                            "result_processing_scores_max_overrun_time", 0
-                        )
-                    )
-                    if (
-                        max_overrun_time.to_msec() > 0
-                        and result_time > max_time + max_overrun_time
-                    ):
-                        result.status = ResultStatus.OVERTIME
+                cls.check_overtime(result)
 
             result.status_comment = StatusComments().get_status_default_comment(
                 result.status
@@ -174,6 +159,30 @@ class ResultChecker:
                 msec=race().get_setting("marked_route_penalty_time", 60000)
             )
             result.penalty_time = time_for_one_penalty * penalty
+
+    @classmethod
+    def check_overtime(cls, result: Result):
+        rp_mode = race().get_setting("result_processing_mode", "time")
+        race_type = result.get_race_type()
+
+        if race_type == RaceType.MULTI_DAY_RACE:
+            result_time = result.get_result_otime_current_day()
+        else:
+            result_time = result.get_result_otime()
+
+        max_time = result.person.group.max_time
+        if rp_mode in ("time", "ardf"):
+            if result_time > max_time:
+                result.status = ResultStatus.OVERTIME
+        elif rp_mode == "scores":
+            max_overrun_time = OTime(
+                msec=race().get_setting("result_processing_scores_max_overrun_time", 0)
+            )
+            if (
+                max_overrun_time.to_msec() > 0
+                and result_time > max_time + max_overrun_time
+            ):
+                result.status = ResultStatus.OVERTIME
 
     @staticmethod
     def get_marked_route_incorrect_list(controls):

--- a/tests/test_result_checking.py
+++ b/tests/test_result_checking.py
@@ -10,11 +10,14 @@ from sportorg.models.memory import (
     Group,
     Person,
     Race,
+    RaceType,
     ResultSportident,
+    ResultStatus,
     Split,
     create,
     new_event,
     race,
+    set_current_race_index,
 )
 from sportorg.models.result.result_checker import ResultChecker
 
@@ -508,6 +511,7 @@ def create_race():
     result = ResultSportident()
     result.person = person
     new_event([create(Race)])
+    set_current_race_index(0)
     race().courses.append(course)
     race().groups.append(group)
     race().persons.append(person)
@@ -564,3 +568,118 @@ def split_and_course_repr(course: List[Union[int, str]], splits: List[int]) -> s
     spl = splits
     crs = course
     return '\n'.join([f'{s:3}  {c}' for s, c in zip_longest(spl, crs, fillvalue='')])
+
+
+def test_overtime_multi_day_race_current_day_exceeds_max_time():
+    course = create(Course)
+
+    # Day 1 — current race, 45 min result
+    group1 = create(Group, course=course)
+    group1.name = "M21"
+    group1.race_type = RaceType.INDIVIDUAL_RACE
+    person1 = create(Person, group=group1)
+    person1.name = "Athlete"
+    person1.start_time = OTime(0, 10, 0, 0)
+    result1 = ResultSportident()
+    result1.person = person1
+    result1.finish_time = OTime(0, 10, 45, 0)
+    day1 = create(Race)
+    day1.groups.append(group1)
+    day1.persons.append(person1)
+    day1.results.append(result1)
+
+    # Day 2 — same athlete (matched by multi_day_id), 65 min result
+    group2 = create(Group, course=course)
+    group2.name = "M21"
+    group2.race_type = RaceType.MULTI_DAY_RACE
+    group2.max_time = OTime(0, 1, 0, 0)
+    person2 = create(Person, group=group2)
+    person2.name = "Athlete"
+    person2.start_time = OTime(0, 10, 0, 0)
+    result2 = ResultSportident()
+    result2.person = person2
+    result2.finish_time = OTime(0, 11, 5, 0)
+    day2 = create(Race)
+    day2.groups.append(group2)
+    day2.persons.append(person2)
+    day2.results.append(result2)
+
+    new_event([day1, day2])
+    set_current_race_index(1) # day2 is current (index 1)
+
+    ResultChecker.check_overtime(result2)
+
+    assert result2.status == ResultStatus.OVERTIME
+
+
+def test_overtime_multi_day_race_current_day_within_max_time():
+    """MULTI_DAY_RACE: OK when today's time is within max_time.
+
+    Cumulative result (45 + 55 = 100 min) exceeds max_time (60 min),
+    but only the current-day time (55 min) should be compared.
+    """
+    course = create(Course)
+
+    # Day 1 — current race, 45 min result
+    group1 = create(Group, course=course)
+    group1.name = "M21"
+    group1.race_type = RaceType.INDIVIDUAL_RACE
+    person1 = create(Person, group=group1)
+    person1.name = "Athlete"
+    person1.start_time = OTime(0, 10, 0, 0)
+    result1 = ResultSportident()
+    result1.person = person1
+    result1.finish_time = OTime(0, 10, 45, 0)
+    day1 = create(Race)
+    day1.groups.append(group1)
+    day1.persons.append(person1)
+    day1.results.append(result1)
+
+    # Day 2 — same athlete (matched by multi_day_id), 55 min result
+    group2 = create(Group, course=course)
+    group2.name = "M21"
+    group2.race_type = RaceType.MULTI_DAY_RACE
+    group2.max_time = OTime(0, 1, 0, 0)
+    person2 = create(Person, group=group2)
+    person2.name = "Athlete"
+    person2.start_time = OTime(0, 10, 0, 0)
+    result2 = ResultSportident()
+    result2.person = person2
+    result2.finish_time = OTime(0, 10, 55, 0)
+    day2 = create(Race)
+    day2.groups.append(group2)
+    day2.persons.append(person2)
+    day2.results.append(result2)
+
+    new_event([day1, day2])
+    set_current_race_index(1) # day2 is current (index 1)
+
+    ResultChecker.check_overtime(result2)
+
+    assert result2.status == ResultStatus.OK
+
+
+def test_overtime_individual_race_exceeds_max_time():
+    create_race()
+    group = race().groups[0]
+    result = race().results[0]
+    group.max_time = OTime(0, 1, 0, 0)
+    result.person.start_time = OTime(0, 10, 0, 0)
+    result.finish_time = OTime(0, 11, 5, 0)  # 65 min > 60 min
+
+    ResultChecker.check_overtime(result)
+
+    assert result.status == ResultStatus.OVERTIME
+
+
+def test_overtime_individual_race_within_max_time():
+    create_race()
+    group = race().groups[0]
+    result = race().results[0]
+    group.max_time = OTime(0, 1, 0, 0)
+    result.person.start_time = OTime(0, 10, 0, 0)
+    result.finish_time = OTime(0, 10, 55, 0)  # 55 min < 60 min
+
+    ResultChecker.check_overtime(result)
+
+    assert result.status == ResultStatus.OK


### PR DESCRIPTION
## Проблема

При многодневных гонках (`MULTI_DAY_RACE`) превышение контрольного времени сравнивалось с суммарным результатом за все дни (`get_result_otime_multi_day`). Это неправильное поведение: контрольное время регламентирует максимальное время нахождения спортсмена на трассе и устанавливается в целях ограничения продолжительности спортивных соревнований (п.5.4.1 Правил спортивного ориентирования). 

## Изменения

**`result_checker.py`** — логика проверки контрольного времени вынесена в отдельный метод `check_overtime`. Для `MULTI_DAY_RACE` теперь используется `get_result_otime_current_day()`, для остальных типов гонок — `get_result_otime()` (поведение не изменилось).

**`memory.py`** — вынесен вспомогательный метод `get_race_type(fallback)`, чтобы не дублировать логику получения типа гонки. Используется в `get_result_otime()` и `check_overtime()`.

## Тесты

Добавлены 4 теста в `test_result_checking.py`:
- `INDIVIDUAL_RACE` + превышение лимита → `OVERTIME`
- `INDIVIDUAL_RACE` + укладывается в лимит → `OK`
- `MULTI_DAY_RACE` + результат дня превышает лимит → `OVERTIME`
- `MULTI_DAY_RACE` + результат дня укладывается в лимит → `OK`