### PR TITLE
style(ui): add info icon to labels with tooltips

### DIFF
--- a/sportorg/gui/dialogs/huichang_management_dialog.py
+++ b/sportorg/gui/dialogs/huichang_management_dialog.py
@@ -1,38 +1,38 @@
-import logging
 import functools
+import logging
 
 try:
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import (
         QDialog,
-        QVBoxLayout,
-        QHBoxLayout,
         QGroupBox,
-        QPushButton,
-        QSpinBox,
-        QRadioButton,
+        QHBoxLayout,
         QLabel,
+        QPushButton,
+        QRadioButton,
+        QSpinBox,
         QStyle,
+        QVBoxLayout,
     )
 except ModuleNotFoundError:
     from PySide2.QtCore import Qt
     from PySide2.QtWidgets import (
         QDialog,
-        QVBoxLayout,
-        QHBoxLayout,
         QGroupBox,
-        QPushButton,
-        QSpinBox,
-        QRadioButton,
+        QHBoxLayout,
         QLabel,
+        QPushButton,
+        QRadioButton,
+        QSpinBox,
         QStyle,
+        QVBoxLayout,
     )
 
-from sportorg.libs.huichang.huichang import Huichang, HuichangException
-from sportorg.modules.sportident.sireader import SIReaderClient
 from sportorg.gui.global_access import GlobalAccess
 from sportorg.gui.utils.custom_controls import AdvComboBox
 from sportorg.language import translate
+from sportorg.libs.huichang.huichang import Huichang, HuichangException
+from sportorg.modules.sportident.sireader import SIReaderClient
 
 
 class HuichangManagementDialog(QDialog):
@@ -51,7 +51,7 @@ class HuichangManagementDialog(QDialog):
         self.setWindowTitle(translate("Huichang Management"))
         self.layout = QVBoxLayout(self)
 
-        self.label_port = QLabel(translate("Port"))
+        self.label_port = QLabel(translate("Port") + " 🛈")
         self.item_port = AdvComboBox()
         self.scan_port_button = QPushButton()
         pixmapi = QStyle.SP_BrowserReload
@@ -71,7 +71,7 @@ class HuichangManagementDialog(QDialog):
         self.time_group_box = QGroupBox(translate("Time Calibration"))
         self.time_layout = QVBoxLayout(self.time_group_box)
 
-        self.time_sync_button = QPushButton(translate("Time Sync"))
+        self.time_sync_button = QPushButton(translate("Time Sync") + " 🛈")
         self.time_sync_button.clicked.connect(self.time_sync)
         self.time_sync_button.setToolTip(
             translate("Send current system time to the connected station")
@@ -97,7 +97,7 @@ class HuichangManagementDialog(QDialog):
         self.station_spin.setValue(31)
         self.station_manual_rb.toggled.connect(self.station_spin.setEnabled)
 
-        self.station_number_apply_button = QPushButton(translate("Apply"))
+        self.station_number_apply_button = QPushButton(translate("Apply") + " 🛈")
         self.station_number_apply_button.setToolTip(
             translate("Set new number for the connected station")
         )

--- a/sportorg/gui/dialogs/timekeeping_properties.py
+++ b/sportorg/gui/dialogs/timekeeping_properties.py
@@ -33,7 +33,7 @@ from sportorg.common.otime import OTime
 from sportorg.gui.global_access import GlobalAccess
 from sportorg.gui.utils.custom_controls import AdvComboBox, AdvSpinBox, AdvTimeEdit
 from sportorg.language import translate
-from sportorg.models.memory import race, SystemType
+from sportorg.models.memory import SystemType, race
 from sportorg.models.result.result_tools import recalculate_results
 from sportorg.modules.sportident.sireader import SIReaderClient
 
@@ -179,7 +179,9 @@ class TimekeepingPropertiesDialog(QDialog):
         self.rp_scores_layout.addRow(
             self.rp_scores_max_overrun_time_label, self.rp_scores_max_overrun_time
         )
-        self.rp_scores_allow_duplicates = QCheckBox(translate("allow duplicates"))
+        self.rp_scores_allow_duplicates = QCheckBox(
+            translate("allow duplicates") + " 🛈"
+        )
         self.rp_scores_allow_duplicates.setToolTip(
             translate(
                 "Use this option to count one punch several times,"
@@ -241,20 +243,20 @@ class TimekeepingPropertiesDialog(QDialog):
         self.mr_off_radio.setToolTip(translate("No penalty"))
         self.mr_off_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_off_radio)
-        self.mr_time_radio = QRadioButton(translate("penalty time"))
+        self.mr_time_radio = QRadioButton(translate("penalty time") + " 🛈")
         self.mr_time_radio.setToolTip(
             translate("Penalty calculation mode: penalty time")
         )
         self.mr_time_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_time_edit = AdvTimeEdit(display_format=self.time_format)
         self.mr_layout.addRow(self.mr_time_radio, self.mr_time_edit)
-        self.mr_laps_radio = QRadioButton(translate("penalty laps"))
+        self.mr_laps_radio = QRadioButton(translate("penalty laps") + " 🛈")
         self.mr_laps_radio.setToolTip(
             translate("Penalty calculation mode: penalty laps")
         )
         self.mr_laps_radio.toggled.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_laps_radio)
-        self.mr_counting_lap_check = QCheckBox(translate("counting lap"))
+        self.mr_counting_lap_check = QCheckBox(translate("counting lap") + " 🛈")
         self.mr_counting_lap_check.setToolTip(
             translate(
                 "Operating mode: evaluation point\n"
@@ -264,7 +266,7 @@ class TimekeepingPropertiesDialog(QDialog):
         )
         self.mr_counting_lap_check.stateChanged.connect(self.penalty_calculation_mode)
         self.mr_layout.addRow(self.mr_counting_lap_check)
-        self.mr_lap_station_check = QCheckBox(translate("lap station"))
+        self.mr_lap_station_check = QCheckBox(translate("lap station") + " 🛈")
         self.mr_lap_station_check.setToolTip(
             translate(
                 "Station number on the penalty lap\n"


### PR DESCRIPTION
Добавлена иконка `🛈` к элементам интерфейса, у которых есть значимая всплывающая подсказка (tooltip) — чтобы пользователь видел, что дополнительная информация доступна. В дальнейшем приветствуется использование иконки при добавлении новых всплывающих подсказок

Также сделана сортировка импортов.