### PR TITLE
feat: add last name and first name to text io

### DIFF
--- a/sportorg/gui/dialogs/text_io.py
+++ b/sportorg/gui/dialogs/text_io.py
@@ -23,10 +23,10 @@ from sportorg.gui.global_access import GlobalAccess
 from sportorg.language import translate
 from sportorg.models.memory import Qualification, ResultManual, race
 from sportorg.utils.time import (
-    hhmmss_to_time,
-    time_to_hhmmss,
     date_to_ddmmyyyy,
     ddmmyyyy_to_time,
+    hhmmss_to_time,
+    time_to_hhmmss,
 )
 
 
@@ -47,6 +47,8 @@ def get_value_options():
         translate("Start group"),
         translate("IOF id"),
         translate("National id"),
+        translate("Last name"),
+        translate("First name"),
         translate("Middle name"),
         translate("Birthday"),
     ]
@@ -354,6 +356,10 @@ def get_property(person, key):
         return str(person.national_code)
     elif key == translate("Start group"):
         return str(person.start_group)
+    elif key == translate("Last name"):
+        return str(person.surname)
+    elif key == translate("First name"):
+        return str(person.name)
     elif key == translate("Middle name"):
         return str(person.middle_name)
     elif key == translate("Birthday"):
@@ -422,6 +428,10 @@ def set_property(person, key, value, **options):
     elif key == translate("Start group"):
         if str(value).isdigit():
             person.start_group = int(value)
+    elif key == translate("Last name"):
+        person.surname = str(value)
+    elif key == translate("First name"):
+        person.name = str(value)
     elif key == translate("Middle name"):
         person.middle_name = str(value)
     elif key == translate("Birthday"):


### PR DESCRIPTION
В текстовый импорт-экспорт добавлены фамилия и имя участника.

Пример использования: массово исправить во внешней программе и вставить обратно в SportOrg