### PR TITLE
fix(printing): apply page margins when printing splits

### DIFF
--- a/sportorg/modules/printing/printing.py
+++ b/sportorg/modules/printing/printing.py
@@ -70,7 +70,7 @@ class PrintProcess(Process):
 
             text_document = QTextDocument()
 
-            printer.setFullPage(True)
+            printer.setFullPage(False)
             if qt_version == 5:
                 printer.setPageMargins(
                     self.margin_left,


### PR DESCRIPTION
Исправлено: не применялись поля при печати сплитов, заданные в настройках печати

При печати сплитов `printer.setFullPage(True)` переопределял поля страницы, из-за чего вызовы `setPageMargins` игнорировались. При `setFullPage(False)` поля, заданные в настройках печати сплитов, применяются корректно.